### PR TITLE
Catching NPEs if null image URLs

### DIFF
--- a/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubAdapter.java
+++ b/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubAdapter.java
@@ -243,13 +243,13 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
             @Override
             public void onImpression(View view) {
                 listener.onAdImpression(MoPubAdapter.this);
-                listener.onAdOpened(MoPubAdapter.this);
                 Log.d(TAG, "onImpression");
             }
 
             @Override
             public void onClick(View view) {
                 listener.onAdClicked(MoPubAdapter.this);
+                listener.onAdOpened(MoPubAdapter.this);
                 listener.onAdLeftApplication(MoPubAdapter.this);
                 Log.d(TAG, "onClick");
             }

--- a/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubAdapter.java
+++ b/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubAdapter.java
@@ -243,12 +243,14 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
             @Override
             public void onImpression(View view) {
                 listener.onAdImpression(MoPubAdapter.this);
+                listener.onAdOpened(MoPubAdapter.this);
                 Log.d(TAG, "onImpression");
             }
 
             @Override
             public void onClick(View view) {
                 listener.onAdClicked(MoPubAdapter.this);
+                listener.onAdLeftApplication(MoPubAdapter.this);
                 Log.d(TAG, "onClick");
             }
         };

--- a/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubAdapter.java
+++ b/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubAdapter.java
@@ -58,6 +58,8 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
     private static final int DEFAULT_MOPUB_PRIVACY_ICON_SIZE_DP = 20;
     private static final int MAXIMUM_MOPUB_PRIVACY_ICON_SIZE_DP = 30;
 
+    public NativeAd.MoPubNativeEventListener moPubNativeEventListener;
+
     @Override
     public void onDestroy() {
 
@@ -121,6 +123,9 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
 
                     @Override
                     public void onNativeLoad(NativeAd nativeAd) {
+                        // Setting a native event listener for MoPub's impression & click events
+                        nativeAd.setMoPubNativeEventListener(moPubNativeEventListener);
+
                         BaseNativeAd adData = nativeAd.getBaseNativeAd();
                         if (adData instanceof StaticNativeAd) {
                             final StaticNativeAd staticNativeAd = (StaticNativeAd) adData;
@@ -144,7 +149,6 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
                                         new URL(staticNativeAd.getMainImageUrl()));
 
                             } catch (MalformedURLException e) {
-                                //return added with fail callbacks - rupa
                                 Log.d(TAG, "Invalid ad response received from MoPub. Image URLs"
                                         + " are invalid");
                                 listener.onAdFailedToLoad(MoPubAdapter.this,
@@ -233,6 +237,21 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
 
         moPubNative.makeRequest(requestParameters);
 
+        // Forwarding MoPub's impression and click events to AdMob
+        moPubNativeEventListener = new NativeAd.MoPubNativeEventListener() {
+
+            @Override
+            public void onImpression(View view) {
+                listener.onAdImpression(MoPubAdapter.this);
+                Log.d(TAG, "onImpression");
+            }
+
+            @Override
+            public void onClick(View view) {
+                listener.onAdClicked(MoPubAdapter.this);
+                Log.d(TAG, "onClick");
+            }
+        };
     }
 
     @Override
@@ -339,7 +358,6 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
             mMediationBannerListener.onAdLoaded(MoPubAdapter.this);
 
         }
-
     }
 
 
@@ -470,4 +488,3 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
         }
     }
 }
-

--- a/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubNativeAppInstallAdMapper.java
+++ b/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubNativeAppInstallAdMapper.java
@@ -66,8 +66,8 @@ public class MoPubNativeAppInstallAdMapper extends NativeAppInstallAdMapper {
             setImages(imagesList);
         }
 
-        setOverrideClickHandling(false);
-        setOverrideImpressionRecording(false);
+        setOverrideClickHandling(true);
+        setOverrideImpressionRecording(true);
     }
 
     @Override

--- a/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubNativeMappedImage.java
+++ b/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubNativeMappedImage.java
@@ -18,14 +18,8 @@ public class MoPubNativeMappedImage extends NativeAd.Image {
 
     public MoPubNativeMappedImage(Drawable drawable, String imageUrl, double scale) {
         mDrawable = drawable;
+        mImageUri = Uri.parse(imageUrl);
         mScale = scale;
-
-        try {
-            mImageUri = Uri.parse(imageUrl);
-        } catch (Exception e) {
-            Log.d(MoPubAdapter.TAG, "Exception trying to parse image URL.");
-            return;
-        }
     }
     
     @Override

--- a/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubNativeMappedImage.java
+++ b/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubNativeMappedImage.java
@@ -18,10 +18,16 @@ public class MoPubNativeMappedImage extends NativeAd.Image {
 
     public MoPubNativeMappedImage(Drawable drawable, String imageUrl, double scale) {
         mDrawable = drawable;
-        mImageUri = Uri.parse(imageUrl);
         mScale = scale;
-    }
 
+        try {
+            mImageUri = Uri.parse(imageUrl);
+        } catch (Exception e) {
+            Log.d(MoPubAdapter.TAG, "Exception trying to parse image URL.");
+            return;
+        }
+    }
+    
     @Override
     public Drawable getDrawable() {
         return mDrawable;


### PR DESCRIPTION
Adding additional try/catch clauses around code blocks that can throw exceptions when certain assets from MoPub are null / not present during parsing. 