### PR TITLE
Adding fixes for bugs reported by publishers during 3.3.0 development

### DIFF
--- a/ThirdPartyAdapters/adcolony/adcolony/src/main/java/com/jirbo/adcolony/AdColonyManager.java
+++ b/ThirdPartyAdapters/adcolony/adcolony/src/main/java/com/jirbo/adcolony/AdColonyManager.java
@@ -51,7 +51,7 @@ class AdColonyManager {
             _context = context; // update the context if its non-null
         }
 
-        if (!(_context instanceof Activity)) {
+        if (_context != null && !(_context instanceof Activity)) {
             Log.w("AdColonyAdapter", "Context must be of type Activity.");
             return false;
         }

--- a/ThirdPartyAdapters/adcolony/adcolony/src/main/java/com/jirbo/adcolony/AdColonyReward.java
+++ b/ThirdPartyAdapters/adcolony/adcolony/src/main/java/com/jirbo/adcolony/AdColonyReward.java
@@ -4,7 +4,6 @@ import com.google.android.gms.ads.reward.RewardItem;
 
 /**
  * A {@link RewardItem} used to map AdColony rewards to Google's rewarded video ad rewards.
- *
  */
 public class AdColonyReward implements RewardItem {
     private String _name;


### PR DESCRIPTION
These changes are in direct response to issues reported to AdColony support by some publishers. An overview of the changes split by issue:

1. When our adapter is destroyed in an app session we drop the Context reference held by AdColonyManager as to not leak. As initialize() is only called once, this leaves us in a state where our instanceof Activity check fails in AdColonyManager's configureAdColony() if a new adapter instance is used later to request ads. Allowing a null context is fine in this case because AdColony has already been configured.

2. Along the same lines, publishers were running into scenarios where when destroying and reinitializing the adapter they are sometimes struggling to get filled ad requests from us. Introducing an idea of request state via the RequestState enum allows us to to pass back ad instances that have been previously requested (but not shown) to the publisher prior to destruction.

3. AdColony's reward callback will occur in the case of reward failures (for instance, when an ad is skipped prior to completion) with a success boolean == false. We now are now checking this flag before invoking the call to onRewarded() such that users aren't incorrectly rewarded in a failure state.