### PR TITLE
Update AppLovin Adapter version number in build.gradle

### DIFF
--- a/ThirdPartyAdapters/applovin/applovin/build.gradle
+++ b/ThirdPartyAdapters/applovin/applovin/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "7.7.0.0"
+    stringVersion = "7.7.0.1"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -21,7 +21,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 26
-        versionCode 70700
+        versionCode 70701
         versionName stringVersion
 
     }


### PR DESCRIPTION
Version 7.7.0.1 has already been tested and merged in #48, but we had forgotten to bump the version number in the `build.gradle` file.