### PR TITLE
Separate keywords passing + Initialize MoPub

### DIFF
--- a/ThirdPartyAdapters/mopub/mopub/build.gradle
+++ b/ThirdPartyAdapters/mopub/mopub/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "4.20.0.0"
+    stringVersion = "5.0.0.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -21,7 +21,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 26
-        versionCode 42000
+        versionCode 5000
         versionName stringVersion
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -40,8 +40,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-ads:11.8.0'
-    implementation('com.mopub:mopub-sdk:4.20.0@aar') {
+    implementation 'com.google.android.gms:play-services-ads:15.0.1'
+    implementation('com.mopub:mopub-sdk:5.0.0@aar') {
         transitive = true
     }
 }

--- a/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubAdapter.java
+++ b/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubAdapter.java
@@ -315,6 +315,9 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
         return mMoPubView;
     }
 
+    /* Keywords passed from AdMob are separated into 1) personally identifiable, and 2) non-personally
+    identifiable categories before they are forwarded to MoPub due to GDPR.
+     */
     private String getKeywords(MediationAdRequest mediationAdRequest, boolean intendedForPII) {
 
         Date birthday = mediationAdRequest.getBirthday();
@@ -510,6 +513,7 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
 
     }
 
+    // Initializing the MoPub SDK. Required as of 5.0.0
     private void initializeMoPub(Context context, String adUnitId) {
         if (!MoPub.isSdkInitialized()) {
             SdkConfiguration sdkConfiguration = new SdkConfiguration.Builder(adUnitId)

--- a/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubAdapter.java
+++ b/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubAdapter.java
@@ -55,7 +55,6 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
         MediationInterstitialAdapter {
     public static final String TAG = MoPubAdapter.class.getSimpleName();
 
-    private boolean isMoPubInitialized = false;
     private MoPubView mMoPubView;
     private AdSize mAdSize;
 
@@ -512,7 +511,7 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
     }
 
     private void initializeMoPub(Context context, String adUnitId) {
-        if (!isMoPubInitialized) {
+        if (!MoPub.isSdkInitialized()) {
             SdkConfiguration sdkConfiguration = new SdkConfiguration.Builder(adUnitId)
                     .build();
             MoPub.initializeSdk(context, sdkConfiguration, initSdkListener());
@@ -525,7 +524,6 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
             @Override
             public void onInitializationFinished() {
                 MoPubLog.d("MoPub SDK initialized.");
-                isMoPubInitialized = true;
             }
         };
     }

--- a/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubAdapter.java
+++ b/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubAdapter.java
@@ -20,6 +20,9 @@ import com.google.android.gms.ads.mediation.MediationInterstitialListener;
 import com.google.android.gms.ads.mediation.MediationNativeAdapter;
 import com.google.android.gms.ads.mediation.MediationNativeListener;
 import com.google.android.gms.ads.mediation.NativeMediationAdRequest;
+import com.mopub.common.MoPub;
+import com.mopub.common.SdkConfiguration;
+import com.mopub.common.SdkInitializationListener;
 import com.mopub.common.logging.MoPubLog;
 import com.mopub.mobileads.MoPubErrorCode;
 import com.mopub.mobileads.MoPubInterstitial;
@@ -52,6 +55,7 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
         MediationInterstitialAdapter {
     public static final String TAG = MoPubAdapter.class.getSimpleName();
 
+    private boolean isMoPubInitialized = false;
     private MoPubView mMoPubView;
     private AdSize mAdSize;
 
@@ -98,6 +102,8 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
                                 Bundle mediationExtras) {
 
         String adunit = serverParameters.getString(MOPUB_AD_UNIT_KEY);
+        initializeMoPub(context, adunit);
+
         final NativeAdOptions options = mediationAdRequest.getNativeAdOptions();
 
         if (options != null)
@@ -282,6 +288,8 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
                                 Bundle bundle1) {
 
         String adunit = bundle.getString(MOPUB_AD_UNIT_KEY);
+        initializeMoPub(context, adunit);
+
 
         mAdSize = adSize;
         mMoPubView = new MoPubView(context);
@@ -420,6 +428,7 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
                                       Bundle bundle1) {
 
         String adunit = bundle.getString(MOPUB_AD_UNIT_KEY);
+        initializeMoPub(context, adunit);
 
         mMoPubInterstitial = new MoPubInterstitial((Activity) context, adunit);
         mMoPubInterstitial.setInterstitialAdListener(
@@ -500,6 +509,25 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
             mMediationInterstitialListener.onAdOpened(MoPubAdapter.this);
         }
 
+    }
+
+    private void initializeMoPub(Context context, String adUnitId) {
+        if (!isMoPubInitialized) {
+            SdkConfiguration sdkConfiguration = new SdkConfiguration.Builder(adUnitId)
+                    .build();
+            MoPub.initializeSdk(context, sdkConfiguration, initSdkListener());
+        }
+    }
+
+    private SdkInitializationListener initSdkListener() {
+        return new SdkInitializationListener() {
+
+            @Override
+            public void onInitializationFinished() {
+                MoPubLog.d("MoPub SDK initialized.");
+                isMoPubInitialized = true;
+            }
+        };
     }
 
     /**

--- a/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubAdapter.java
+++ b/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubAdapter.java
@@ -246,7 +246,8 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
                         RequestParameters.NativeAdAsset.ICON_IMAGE);
 
         RequestParameters requestParameters = new RequestParameters.Builder()
-                .keywords(getKeywords(mediationAdRequest))
+                .keywords(getKeywords(mediationAdRequest, false))
+                .userDataKeywords(getKeywords(mediationAdRequest, true))
                 .location(mediationAdRequest.getLocation())
                 .desiredAssets(assetsSet)
                 .build();
@@ -297,7 +298,8 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
             mMoPubView.setLocation(mediationAdRequest.getLocation());
         }
 
-        mMoPubView.setKeywords(getKeywords(mediationAdRequest));
+        mMoPubView.setKeywords(getKeywords(mediationAdRequest, false));
+        mMoPubView.setUserDataKeywords(getKeywords(mediationAdRequest, true));
         mMoPubView.loadAd();
     }
 
@@ -306,7 +308,7 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
         return mMoPubView;
     }
 
-    private String getKeywords(MediationAdRequest mediationAdRequest) {
+    private String getKeywords(MediationAdRequest mediationAdRequest, boolean intendedForPII) {
 
         Date birthday = mediationAdRequest.getBirthday();
         String ageString = "";
@@ -333,7 +335,17 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
                 .append(",").append(ageString)
                 .append(",").append(genderString);
 
-        return keywordsBuilder.toString();
+        if (intendedForPII) {
+            return keywordsContainPII(mediationAdRequest) ? keywordsBuilder.toString() : "";
+        } else {
+            return keywordsContainPII(mediationAdRequest) ? "" : keywordsBuilder.toString();
+        }
+    }
+
+    // Check whether passed keywords contain personally-identifiable information
+    private boolean keywordsContainPII(MediationAdRequest mediationAdRequest) {
+        return mediationAdRequest.getBirthday() != null || mediationAdRequest.getGender() !=
+                -1 || mediationAdRequest.getLocation() != null;
     }
 
     private static int getAge(Date birthday) {
@@ -400,7 +412,6 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
         }
     }
 
-
     @Override
     public void requestInterstitialAd(Context context,
                                       MediationInterstitialListener mediationInterstitialListener,
@@ -419,7 +430,9 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
             mMoPubInterstitial.setTesting(true);
         }
 
-        mMoPubInterstitial.setKeywords(getKeywords(mediationAdRequest));
+        mMoPubInterstitial.setKeywords(getKeywords(mediationAdRequest, false));
+        mMoPubInterstitial.setKeywords(getKeywords(mediationAdRequest, true));
+
         mMoPubInterstitial.load();
     }
 


### PR DESCRIPTION
* As of MoPub 5.0.0, keywords needed to be separate into two APIs based on whether they contain personally identifiable information.
* Initialize the MoPub SDK in the adapter with a valid ad unit ID from the publisher's app.