### PR TITLE
Bump version to 3.3.4, pass GDPR consent to AdColony

### DIFF
--- a/ThirdPartyAdapters/adcolony/adcolony/build.gradle
+++ b/ThirdPartyAdapters/adcolony/adcolony/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "3.3.3.0"
+    stringVersion = "3.3.4.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -21,7 +21,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 26
-        versionCode 30330
+        versionCode 30340
         versionName stringVersion
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -39,7 +39,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.adcolony:sdk:3.3.3'
+    implementation 'com.adcolony:sdk:3.3.4'
     implementation 'com.google.android.gms:play-services-ads:15.0.0'
 }
 

--- a/ThirdPartyAdapters/adcolony/adcolony/src/main/java/com/jirbo/adcolony/AdColonyBundleBuilder.java
+++ b/ThirdPartyAdapters/adcolony/adcolony/src/main/java/com/jirbo/adcolony/AdColonyBundleBuilder.java
@@ -11,6 +11,8 @@ public class AdColonyBundleBuilder {
     private static boolean _showPreAdPopup;
     private static boolean _showPostAdPopup;
     private static String _userId;
+    private static String _gdprConsentString;
+    private static boolean _gdprRequired;
 
     public static void setZoneId(String requestedZone) {
         _zoneId = requestedZone;
@@ -28,12 +30,35 @@ public class AdColonyBundleBuilder {
         _showPostAdPopup = showPostPopupValue;
     }
 
+    /**
+     * This is to inform the AdColony service if GDPR should be considered for the user based on
+     * if they are EU citizens or from EU territories.
+     *
+     * @param gdprRequired whether or not we need to consider GDPR for this user.
+     */
+    public static void setGdprRequired(boolean gdprRequired) {
+        _gdprRequired = gdprRequired;
+    }
+
+    /**
+     * Used to set the user's GDPR consent String. This was originally designed for IAB compliance,
+     * but for now please follow AdColony's GDPR documentation for setting this value:
+     * https://github.com/AdColony/AdColony-Android-SDK-3/wiki/GDPR
+     *
+     * @param gdprConsentString the user's GDPR consent String
+     */
+    public static void setGdprConsentString(String gdprConsentString) {
+        _gdprConsentString = gdprConsentString;
+    }
+
     public static Bundle build() {
         Bundle bundle = new Bundle();
         bundle.putString("zone_id", _zoneId);
         bundle.putString("user_id", _userId);
         bundle.putBoolean("show_pre_popup", _showPreAdPopup);
         bundle.putBoolean("show_post_popup", _showPostAdPopup);
+        bundle.putBoolean("gdpr_required", _gdprRequired);
+        bundle.putString("gdpr_consent_string", _gdprConsentString);
         return bundle;
     }
 }

--- a/ThirdPartyAdapters/adcolony/adcolony/src/main/java/com/jirbo/adcolony/AdColonyManager.java
+++ b/ThirdPartyAdapters/adcolony/adcolony/src/main/java/com/jirbo/adcolony/AdColonyManager.java
@@ -117,8 +117,17 @@ class AdColonyManager {
 
         if (networkExtras != null) {
             String userId = networkExtras.getString("user_id");
+            String gdprConsentString = networkExtras.getString("gdpr_consent_string");
             if (userId != null) {
                 options.setUserID(userId);
+                updatedOptions = true;
+            }
+            if (gdprConsentString != null) {
+                options.setGDPRConsentString(gdprConsentString);
+                updatedOptions = true;
+            }
+            if (networkExtras.containsKey("gdpr_required")) {
+                options.setGDPRRequired(networkExtras.getBoolean("gdpr_required"));
                 updatedOptions = true;
             }
         }


### PR DESCRIPTION
Now collecting consent via AdColonyBundleBuilder instead of forwarding AdMob "npa" string as discussed in this revert: https://github.com/googleads/googleads-mobile-android-mediation/pull/82