### PR TITLE
Initialize MoPub manually

### DIFF
--- a/ThirdPartyAdapters/mopub/CHANGELOG.md
+++ b/ThirdPartyAdapters/mopub/CHANGELOG.md
@@ -1,5 +1,8 @@
 # MoPub Adapter for Google Mobile Ads SDK for Android Changelog
 
+## 5.3.0.1
+- Initialize MoPub and reattempt ad requests manually in the adapters for use cases that do not do so in the app.
+
 ## 5.3.0.0
 - Verified compatibility with MoPub SDK 5.3.0.
 


### PR DESCRIPTION
This is helpful for publishers who do not already initialize MoPub in their apps. In that scenario, starting in MoPub 5.2.0, ad requests are canceled. The adapters will check for initialization status first, and will initialize MoPub manually in the adapter and retry the ad requests on the publisher's behalf. This PR ensures that all ad requests to MoPub will go through.