### PR TITLE
 Updated Facebook Audience Network Adapter to version 5.2.0-beta

### DIFF
--- a/ThirdPartyAdapters/applovin/CHANGELOG.md
+++ b/ThirdPartyAdapters/applovin/CHANGELOG.md
@@ -1,5 +1,8 @@
 # AppLovin Adapter for Google Mobile Ads SDK for Android
 
+## 9.2.1.0
+- Verified compatibility with AppLovin SDK 9.2.1
+
 ## 9.1.3.0
 - Removed support for placements as they were deprecated by AppLovin SDK.
 - Verified compatibility with AppLovin SDK 9.1.3

--- a/ThirdPartyAdapters/applovin/applovin/build.gradle
+++ b/ThirdPartyAdapters/applovin/applovin/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "9.1.3.0"
+    stringVersion = "9.2.1.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -21,7 +21,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 26
-        versionCode 9130
+        versionCode 9210
         versionName stringVersion
 
     }
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.applovin:applovin-sdk:9.1.3'
+    implementation 'com.applovin:applovin-sdk:9.2.1'
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.google.android.gms:play-services-ads:17.1.1'
 }

--- a/ThirdPartyAdapters/applovin/build.gradle
+++ b/ThirdPartyAdapters/applovin/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ThirdPartyAdapters/applovin/gradle/wrapper/gradle-wrapper.properties
+++ b/ThirdPartyAdapters/applovin/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/ThirdPartyAdapters/chartboost/CHANGELOG.md
+++ b/ThirdPartyAdapters/chartboost/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Chartboost Adapter for Google Mobile Ads SDK for Android Changelog
 
+## 7.3.1.0
+- Verified compatibility with Chartboost SDK 7.3.1.
+
 ## 7.3.0.0
 - Verified compatibility with Chartboost SDK 7.3.0.
 

--- a/ThirdPartyAdapters/chartboost/chartboost/build.gradle
+++ b/ThirdPartyAdapters/chartboost/chartboost/build.gradle
@@ -9,19 +9,23 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "7.3.0.0"
+    stringVersion = "7.3.1.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
 
 android {
+    lintOptions {
+        abortOnError false
+    }
+
     compileSdkVersion 27
     buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 27
-        versionCode 70300
+        versionCode 70310
         versionName stringVersion
     }
     buildTypes {
@@ -36,7 +40,9 @@ dependencies {
     // Adding Chartboost SDK as a compileOnly dependency makes sure that the jar is not included in the
     // AAR.
     compileOnly files('libs/chartboost.jar')
-    implementation 'com.google.android.gms:play-services-ads:15.0.1'
+    implementation 'com.google.android.gms:play-services-ads:17.1.1'
+    implementation "com.google.android.gms:play-services-base:16.1.0"
+    implementation "com.google.android.gms:play-services-ads-identifier:16.0.0"
 }
 
 /**

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostAdapter.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostAdapter.java
@@ -41,7 +41,7 @@ public class ChartboostAdapter implements MediationRewardedVideoAdAdapter,
     /**
      * The current version of the adapter.
      */
-    public static final String ADAPTER_VERSION_NAME = "7.3.0.0";
+    public static final String ADAPTER_VERSION_NAME = "7.3.1.0";
 
     /**
      * Key to obtain App ID, required for initializing Chartboost SDK.

--- a/ThirdPartyAdapters/duad/CHANGELOG.md
+++ b/ThirdPartyAdapters/duad/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Du Ad Adapter for Google Mobile Ads SDK for Android Changelog
 
+## 1.2.2.0.0
+- Verified compatibility with DuAd SDK 1.2.2 and DuAd Video Ads SDK 1.0.9.2.
+
 ## 1.1.1.8.0
 - Verified compatibility with DuAd SDK 1.1.1.8 and DuAd Video Ads SDK 1.0.7.2.
 
 ## 1.1.1.4.0
 - Verified compatibility with DuAd SDK 1.1.1.4 and DuAd Video Ads SDK 1.0.7.1.
 
-## 1.0.0
+## 1.0.0.0.0
 - Initial release.
 - Supports reward-based video ads and interstitial ads.

--- a/ThirdPartyAdapters/duad/build.gradle
+++ b/ThirdPartyAdapters/duad/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/ThirdPartyAdapters/duad/duadplatform/build.gradle
+++ b/ThirdPartyAdapters/duad/duadplatform/build.gradle
@@ -1,6 +1,4 @@
-plugins {
-    id "com.jfrog.bintray"
-}
+apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 
@@ -9,7 +7,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "1.1.1.8.0"
+    stringVersion = "1.2.2.0.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -20,7 +18,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 26
-        versionCode 11180
+        versionCode 12200
         versionName stringVersion
     }
     buildTypes {
@@ -34,7 +32,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.aar'])
     implementation 'com.android.support:palette-v7:26.1.0'
-    implementation 'com.google.android.gms:play-services-ads:15.0.1'
+    implementation 'com.google.android.gms:play-services-ads:17.1.1'
 }
 
 /**

--- a/ThirdPartyAdapters/duad/gradle/wrapper/gradle-wrapper.properties
+++ b/ThirdPartyAdapters/duad/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Tue Jan 29 12:21:36 PST 2019
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/ThirdPartyAdapters/facebook/CHANGELOG.md
+++ b/ThirdPartyAdapters/facebook/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Facebook Adapter for Google Mobile Ads SDK for Android Changelog
 
+## 5.1.1.0
+- Replaced AdChoices View with AdOptions View.
+- Verified compatibility with Facebook SDK v5.1.1
+
 ## 5.1.0.1
 - Fixed an ANR issue caused by 'getGMSVersionCode()'.
 

--- a/ThirdPartyAdapters/facebook/CHANGELOG.md
+++ b/ThirdPartyAdapters/facebook/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Facebook Adapter for Google Mobile Ads SDK for Android Changelog
 
+## 5.2.0.0-beta
+- Removed usages of NativeAdView attributes.
+- Added NativeAdLayout to Native Ads using a FrameLayout as root.
+
 ## 5.1.1.0
 - Replaced AdChoices View with AdOptions View.
 - Verified compatibility with Facebook SDK v5.1.1

--- a/ThirdPartyAdapters/facebook/build.gradle
+++ b/ThirdPartyAdapters/facebook/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ThirdPartyAdapters/facebook/facebook/build.gradle
+++ b/ThirdPartyAdapters/facebook/facebook/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "5.1.0.1"
+    stringVersion = "5.1.1.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -20,7 +20,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 26
-        versionCode 51001
+        versionCode 51100
         versionName stringVersion
     }
     buildTypes {
@@ -34,7 +34,7 @@ android {
 dependencies {
     implementation 'com.android.support:recyclerview-v7:26.1.0'
     implementation 'com.google.android.gms:play-services-ads:17.1.1'
-    implementation 'com.facebook.android:audience-network-sdk:5.1.0'
+    implementation 'com.facebook.android:audience-network-sdk:5.1.1'
 }
 
 /**

--- a/ThirdPartyAdapters/facebook/facebook/build.gradle
+++ b/ThirdPartyAdapters/facebook/facebook/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "5.1.1.0"
+    stringVersion = "5.2.0.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -20,7 +20,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 26
-        versionCode 51100
+        versionCode 52000
         versionName stringVersion
     }
     buildTypes {
@@ -34,7 +34,7 @@ android {
 dependencies {
     implementation 'com.android.support:recyclerview-v7:26.1.0'
     implementation 'com.google.android.gms:play-services-ads:17.1.1'
-    implementation 'com.facebook.android:audience-network-sdk:5.1.1'
+    implementation 'com.facebook.android:audience-network-sdk:5.2.0-beta'
 }
 
 /**

--- a/ThirdPartyAdapters/facebook/facebook/src/main/java/com/google/ads/mediation/facebook/FacebookAdapter.java
+++ b/ThirdPartyAdapters/facebook/facebook/src/main/java/com/google/ads/mediation/facebook/FacebookAdapter.java
@@ -34,9 +34,9 @@ import android.widget.ImageView;
 import android.widget.RelativeLayout;
 
 import com.facebook.ads.Ad;
-import com.facebook.ads.AdChoicesView;
 import com.facebook.ads.AdError;
 import com.facebook.ads.AdListener;
+import com.facebook.ads.AdOptionsView;
 import com.facebook.ads.AdSettings;
 import com.facebook.ads.AdView;
 import com.facebook.ads.AudienceNetworkAds;
@@ -45,6 +45,7 @@ import com.facebook.ads.InterstitialAdListener;
 import com.facebook.ads.MediaView;
 import com.facebook.ads.MediaViewListener;
 import com.facebook.ads.NativeAd;
+import com.facebook.ads.NativeAdLayout;
 import com.facebook.ads.NativeAdListener;
 import com.facebook.ads.NativeAdViewAttributes;
 import com.facebook.ads.RewardedVideoAd;
@@ -139,12 +140,6 @@ public final class FacebookAdapter
      * sent to the Google Mobile Ads SDK.
      */
     private boolean mIsImpressionRecorded;
-
-    /**
-     * Flag to determine whether or not to make AdChoices icon for native ads expandable.
-     * {@code true} by default.
-     */
-    private boolean mIsAdChoicesIconExpandable = true;
 
     /**
      * A Facebook {@link MediaView} used to show native ad media content.
@@ -400,12 +395,6 @@ public final class FacebookAdapter
         }
 
         String placementId = serverParameters.getString(PLACEMENT_PARAMETER);
-
-        // Get the optional extras if set by the publisher.
-        if (mediationExtras != null) {
-            mIsAdChoicesIconExpandable = mediationExtras.getBoolean(
-                    FacebookExtrasBundleBuilder.KEY_EXPANDABLE_ICON, true);
-        }
 
         mMediaView = new MediaView(context);
 
@@ -946,15 +935,15 @@ public final class FacebookAdapter
             // Find the overlay view in the given ad view. The overlay view will always be the
             // top most view in the hierarchy.
             View overlayView = adView.getChildAt(adView.getChildCount() - 1);
+            NativeAdLayout nativeAdLayout = new NativeAdLayout(view.getContext());
             if (overlayView instanceof FrameLayout) {
-                // Create and add Facebook's AdChoicesView to the overlay view.
-                AdChoicesView adChoicesView =
-                        new AdChoicesView(view.getContext(), mNativeAd, mIsAdChoicesIconExpandable);
-                ((ViewGroup) overlayView).addView(adChoicesView);
+                // Create and add Facebook's AdOptions to the overlay view.
+                AdOptionsView adOptionsView = new AdOptionsView(view.getContext(),mNativeAd,nativeAdLayout);
+                ((ViewGroup) overlayView).addView(adOptionsView);
                 // We know that the overlay view is a FrameLayout, so we get the FrameLayout's
-                // LayoutParams from the AdChoicesView.
+                // LayoutParams from the AdOptionsView.
                 FrameLayout.LayoutParams params =
-                        (FrameLayout.LayoutParams) adChoicesView.getLayoutParams();
+                        (FrameLayout.LayoutParams) adOptionsView.getLayoutParams();
                 if (mNativeAdOptions != null) {
                     switch (mNativeAdOptions.getAdChoicesPlacement()) {
                         case NativeAdOptions.ADCHOICES_TOP_LEFT:
@@ -976,11 +965,8 @@ public final class FacebookAdapter
                 }
                 adView.requestLayout();
             } else {
-
-                AdChoicesView adChoicesView =
-                        new AdChoicesView(view.getContext(), mNativeAd, mIsAdChoicesIconExpandable);
-                this.setAdChoicesContent(adChoicesView);
-
+                AdOptionsView adOptionsView = new AdOptionsView(view.getContext(), mNativeAd, nativeAdLayout);
+                this.setAdChoicesContent(adOptionsView);
             }
 
             // Facebook does its own impression tracking.
@@ -1030,35 +1016,6 @@ public final class FacebookAdapter
                 return null;
             }
             return (MAX_STAR_RATING * rating.getValue()) / rating.getScale();
-        }
-    }
-
-    /**
-     * The {@link FacebookExtrasBundleBuilder} class is used to create a network extras bundle that
-     * can be passed to the adapter to make network specific customizations.
-     */
-    public static class FacebookExtrasBundleBuilder {
-
-        /**
-         * Key to add and obtain {@link #mIsExpandableIcon}.
-         */
-        private static final String KEY_EXPANDABLE_ICON = "expandable_icon";
-
-        /**
-         * Whether or not ad choices icon for native ads is expandable.
-         */
-        private boolean mIsExpandableIcon;
-
-        public FacebookExtrasBundleBuilder setNativeAdChoicesIconExpandable(
-                boolean isExpandableIcon) {
-            this.mIsExpandableIcon = isExpandableIcon;
-            return FacebookExtrasBundleBuilder.this;
-        }
-
-        public Bundle build() {
-            Bundle bundle = new Bundle();
-            bundle.putBoolean(KEY_EXPANDABLE_ICON, mIsExpandableIcon);
-            return bundle;
         }
     }
 

--- a/ThirdPartyAdapters/facebook/facebook/src/main/java/com/google/ads/mediation/facebook/FacebookAdapter.java
+++ b/ThirdPartyAdapters/facebook/facebook/src/main/java/com/google/ads/mediation/facebook/FacebookAdapter.java
@@ -17,7 +17,6 @@ package com.google.ads.mediation.facebook;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
-import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -47,7 +46,6 @@ import com.facebook.ads.MediaViewListener;
 import com.facebook.ads.NativeAd;
 import com.facebook.ads.NativeAdLayout;
 import com.facebook.ads.NativeAdListener;
-import com.facebook.ads.NativeAdViewAttributes;
 import com.facebook.ads.RewardedVideoAd;
 import com.facebook.ads.RewardedVideoAdListener;
 import com.google.android.gms.ads.AdRequest;
@@ -79,1012 +77,974 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @Keep
 public final class FacebookAdapter
-        implements MediationBannerAdapter, MediationInterstitialAdapter,
-        MediationRewardedVideoAdAdapter, MediationNativeAdapter {
+    implements MediationBannerAdapter, MediationInterstitialAdapter,
+    MediationRewardedVideoAdAdapter, MediationNativeAdapter {
 
-    public static final String KEY_AD_VIEW_ATTRIBUTES = "ad_view_attributes";
-    public static final String KEY_AUTOPLAY = "autoplay";
-    public static final String KEY_BACKGROUND_COLOR = "background_color";
-    public static final String KEY_BUTTON_BORDER_COLOR = "button_border_color";
-    public static final String KEY_BUTTON_COLOR = "button_color";
-    public static final String KEY_BUTTON_TEXT_COLOR = "button_text_color";
-    public static final String KEY_DESCRIPTION_TEXT_COLOR = "description_text_color";
-    public static final String KEY_DESCRIPTION_TEXT_SIZE = "description_text_size";
-    public static final String KEY_ID = "id";
-    public static final String KEY_IS_BOLD = "is_bold";
-    public static final String KEY_IS_ITALIC = "is_italic";
-    public static final String KEY_SOCIAL_CONTEXT_ASSET = "social_context";
-    public static final String KEY_STYLE = "style";
-    public static final String KEY_SUBTITLE_ASSET = "subtitle";
-    public static final String KEY_TITLE_TEXT_COLOR = "title_text_color";
-    public static final String KEY_TITLE_TEXT_SIZE = "title_text_size";
-    public static final String KEY_TYPEFACE = "typeface";
+  public static final String KEY_ID = "id";
+  public static final String KEY_SOCIAL_CONTEXT_ASSET = "social_context";
 
-    private static final String PLACEMENT_PARAMETER = "pubid";
+  private static final String PLACEMENT_PARAMETER = "pubid";
 
-    private static final int MAX_STAR_RATING = 5;
-    private static final String TAG = "FacebookAdapter";
+  private static final int MAX_STAR_RATING = 5;
+  private static final String TAG = "FacebookAdapter";
 
-    private static AtomicInteger gmsVersion = new AtomicInteger(0);
+  private static AtomicInteger gmsVersion = new AtomicInteger(0);
 
-    private MediationBannerListener mBannerListener;
-    private MediationInterstitialListener mInterstitialListener;
+  private MediationBannerListener mBannerListener;
+  private MediationInterstitialListener mInterstitialListener;
+
+  /**
+   * Mediation rewarded video ad listener used to forward reward-based video ad events from
+   * Facebook SDK to Google Mobile Ads SDK.
+   */
+  private MediationRewardedVideoAdListener mRewardedListener;
+  private MediationNativeListener mNativeListener;
+  private AdView mAdView;
+  private RelativeLayout mWrappedAdView;
+  private InterstitialAd mInterstitialAd;
+
+  /**
+   * Facebook rewarded video ad instance.
+   */
+  private String mPlacementId;
+  private RewardedVideoAd mRewardedVideoAd;
+
+  private Context mContext;
+
+  private NativeAd mNativeAd;
+
+  /**
+   * Flag to determine whether or not the rewarded video adapter has been initialized.
+   */
+  private boolean mIsInitialized;
+
+  /**
+   * Flag to determine whether or not an impression callback from Facebook SDK has already been
+   * sent to the Google Mobile Ads SDK.
+   */
+  private boolean mIsImpressionRecorded;
+
+  /**
+   * A Facebook {@link MediaView} used to show native ad media content.
+   */
+  private MediaView mMediaView;
+
+  /**
+   * Flag to determine whether or not the Audience Network SDK has been initialized.
+   */
+  private AtomicBoolean mIsSdkInitialized = new AtomicBoolean(false);
+
+  //region MediationAdapter implementation.
+  @Override
+  public void onDestroy() {
+    if (mAdView != null) {
+      mAdView.destroy();
+    }
+    if (mInterstitialAd != null) {
+      mInterstitialAd.destroy();
+    }
+    if (mNativeAd != null) {
+      mNativeAd.unregisterView();
+      mNativeAd.destroy();
+    }
+    if (mMediaView != null) {
+      mMediaView.destroy();
+    }
+    if (mRewardedVideoAd != null) {
+      mRewardedVideoAd.destroy();
+    }
+  }
+
+  @Override
+  public void onPause() {
+    // Do nothing.
+  }
+
+  @Override
+  public void onResume() {
+    // Do nothing.
+  }
+  //endregion
+
+  //region MediationBannerAdapter implementation.
+  @Override
+  public void requestBannerAd(Context context,
+      MediationBannerListener listener,
+      Bundle serverParameters,
+      AdSize adSize,
+      MediationAdRequest adRequest,
+      Bundle mediationExtras) {
+    mBannerListener = listener;
+    if (!mIsSdkInitialized.getAndSet(true)) {
+      AudienceNetworkAds.initialize(context);
+    }
+    if (!isValidRequestParameters(context, serverParameters)) {
+      mBannerListener.onAdFailedToLoad(
+          FacebookAdapter.this, AdRequest.ERROR_CODE_INVALID_REQUEST);
+      return;
+    }
+    if (adSize == null) {
+      Log.w(TAG, "Fail to request banner ad, adSize is null");
+      mBannerListener.onAdFailedToLoad(this, AdRequest.ERROR_CODE_INVALID_REQUEST);
+      return;
+    }
+
+    String placementId = serverParameters.getString(PLACEMENT_PARAMETER);
+
+    com.facebook.ads.AdSize facebookAdSize = getAdSize(context, adSize);
+    if (facebookAdSize == null) {
+      Log.w(TAG,
+          "The input ad size " + adSize.toString() + " is not supported at this moment.");
+      mBannerListener.onAdFailedToLoad(this, AdRequest.ERROR_CODE_NO_FILL);
+      return;
+    }
+    mAdView = new AdView(context, placementId, facebookAdSize);
+    mAdView.setAdListener(new BannerListener());
+    buildAdRequest(adRequest);
+    RelativeLayout.LayoutParams adViewLayoutParams = new RelativeLayout.LayoutParams(
+        adSize.getWidthInPixels(context), adSize.getHeightInPixels(context));
+    mWrappedAdView = new RelativeLayout(context);
+    mAdView.setLayoutParams(adViewLayoutParams);
+    mWrappedAdView.addView(mAdView);
+    if (gmsVersion.get() == 0) {
+      GMSVersionUpdateTask gmsVersionUpdateTask = new GMSVersionUpdateTask(context);
+      gmsVersionUpdateTask.Task(new GMSVersionUpdateTask.OnGMSUpdateListener() {
+        @Override
+        public void OnGMSVersionUpdate() {
+          AdSettings.setMediationService("ADMOB_" + gmsVersion);
+          mAdView.loadAd();
+        }
+      });
+      gmsVersionUpdateTask.execute();
+    } else {
+      AdSettings.setMediationService("ADMOB_" + gmsVersion);
+      mAdView.loadAd();
+    }
+  }
+
+  @Override
+  public View getBannerView() {
+    return mWrappedAdView;
+  }
+  //endregion
+
+  //region MediationInterstitialAdapter implementation.
+  @Override
+  public void requestInterstitialAd(Context context,
+      MediationInterstitialListener listener,
+      Bundle serverParameters,
+      MediationAdRequest adRequest,
+      Bundle mediationExtras) {
+    mInterstitialListener = listener;
+    if (!mIsSdkInitialized.getAndSet(true)) {
+      AudienceNetworkAds.initialize(context);
+    }
+    if (!isValidRequestParameters(context, serverParameters)) {
+      mInterstitialListener.onAdFailedToLoad(this, AdRequest.ERROR_CODE_INVALID_REQUEST);
+      return;
+    }
+
+    String placementId = serverParameters.getString(PLACEMENT_PARAMETER);
+
+    mInterstitialAd = new InterstitialAd(context, placementId);
+    mInterstitialAd.setAdListener(new InterstitialListener());
+    buildAdRequest(adRequest);
+    if (gmsVersion.get() == 0) {
+      GMSVersionUpdateTask gmsVersionUpdateTask = new GMSVersionUpdateTask(context);
+      gmsVersionUpdateTask.Task(new GMSVersionUpdateTask.OnGMSUpdateListener() {
+        @Override
+        public void OnGMSVersionUpdate() {
+          AdSettings.setMediationService("ADMOB_" + gmsVersion);
+          mInterstitialAd.loadAd();
+        }
+      });
+      gmsVersionUpdateTask.execute();
+    } else {
+      AdSettings.setMediationService("ADMOB_" + gmsVersion);
+      mInterstitialAd.loadAd();
+    }
+  }
+
+  @Override
+  public void showInterstitial() {
+    if (mInterstitialAd.isAdLoaded()) {
+      mInterstitialAd.show();
+    }
+  }
+  //endregion
+
+  //region MediationRewardedVideoAdAdapter implementation.
+  @Override
+  public void initialize(Context context,
+      MediationAdRequest mediationAdRequest,
+      String unused,
+      MediationRewardedVideoAdListener mediationRewardedVideoAdListener,
+      Bundle serverParameters,
+      Bundle networkExtras) {
+    mContext = context;
+    if (!mIsSdkInitialized.getAndSet(true)) {
+      AudienceNetworkAds.initialize(context);
+    }
+    mRewardedListener = mediationRewardedVideoAdListener;
+    if (!isValidRequestParameters(context, serverParameters)) {
+      mRewardedListener.onAdFailedToLoad(this, AdRequest.ERROR_CODE_INVALID_REQUEST);
+      return;
+    }
+
+    mPlacementId = serverParameters.getString(PLACEMENT_PARAMETER);
+    mIsInitialized = true;
+    mRewardedListener.onInitializationSucceeded(this);
+  }
+
+  @Override
+  public void loadAd(MediationAdRequest mediationAdRequest,
+      Bundle serverParameters,
+      Bundle networkExtras) {
+    if (mRewardedVideoAd == null) {
+      mRewardedVideoAd = new RewardedVideoAd(mContext, mPlacementId);
+      mRewardedVideoAd.setAdListener(new RewardedVideoListener());
+    }
+
+    if (mRewardedVideoAd.isAdLoaded()) {
+      mRewardedListener.onAdLoaded(this);
+    } else {
+      buildAdRequest(mediationAdRequest);
+      if (gmsVersion.get() == 0) {
+        GMSVersionUpdateTask gmsVersionUpdateTask = new GMSVersionUpdateTask(mContext);
+        gmsVersionUpdateTask.Task(new GMSVersionUpdateTask.OnGMSUpdateListener() {
+          @Override
+          public void OnGMSVersionUpdate() {
+            AdSettings.setMediationService("ADMOB_" + gmsVersion);
+            mRewardedVideoAd.loadAd(true);
+          }
+        });
+        gmsVersionUpdateTask.execute();
+      } else {
+        AdSettings.setMediationService("ADMOB_" + gmsVersion);
+        mRewardedVideoAd.loadAd(true);
+      }
+    }
+  }
+
+  @Override
+  public void showVideo() {
+    if (mRewardedVideoAd != null && mRewardedVideoAd.isAdLoaded()) {
+      mRewardedVideoAd.show();
+      // Facebook's rewarded video listener does not have an equivalent callback for
+      // onAdOpened() but an ad is shown immediately after calling show(), so sending an
+      // onAdOpened callback.
+      mRewardedListener.onAdOpened(FacebookAdapter.this);
+      mRewardedListener.onVideoStarted(FacebookAdapter.this);
+    } else {
+      // No ads to show, but already sent onAdLoaded. Log a warning and send ad opened and
+      // ad closed callbacks.
+      Log.w(TAG, "No ads to show.");
+      if (mRewardedListener != null) {
+        mRewardedListener.onAdOpened(this);
+        mRewardedListener.onAdClosed(this);
+      }
+    }
+  }
+
+  @Override
+  public boolean isInitialized() {
+    return mIsInitialized;
+  }
+  //endregion
+
+  //region MediationNativeAdapter implementation.
+  @Override
+  public void requestNativeAd(Context context,
+      MediationNativeListener listener,
+      Bundle serverParameters,
+      NativeMediationAdRequest mediationAdRequest,
+      Bundle mediationExtras) {
+    mNativeListener = listener;
+    if (!mIsSdkInitialized.getAndSet(true)) {
+      AudienceNetworkAds.initialize(context);
+    }
+    if (!isValidRequestParameters(context, serverParameters)) {
+      mNativeListener.onAdFailedToLoad(this, AdRequest.ERROR_CODE_INVALID_REQUEST);
+      return;
+    }
+
+    // Verify that the request is for both app install and content ads.
+    if (!(mediationAdRequest.isAppInstallAdRequested()
+        && mediationAdRequest.isContentAdRequested())) {
+      Log.w(TAG, "Failed to request native ad. Both app install and content ad should be "
+          + "requested");
+      mNativeListener.onAdFailedToLoad(this, AdRequest.ERROR_CODE_INVALID_REQUEST);
+      return;
+    }
+
+    String placementId = serverParameters.getString(PLACEMENT_PARAMETER);
+
+    mMediaView = new MediaView(context);
+
+    mNativeAd = new NativeAd(context, placementId);
+    mNativeAd.setAdListener(new NativeListener(mNativeAd, mediationAdRequest));
+    buildAdRequest(mediationAdRequest);
+    if (gmsVersion.get() == 0) {
+      GMSVersionUpdateTask gmsVersionUpdateTask = new GMSVersionUpdateTask(context);
+      gmsVersionUpdateTask.Task(new GMSVersionUpdateTask.OnGMSUpdateListener() {
+        @Override
+        public void OnGMSVersionUpdate() {
+          AdSettings.setMediationService("ADMOB_" + gmsVersion);
+          mNativeAd.loadAd();
+        }
+      });
+      gmsVersionUpdateTask.execute();
+    } else {
+      AdSettings.setMediationService("ADMOB_" + gmsVersion);
+      mNativeAd.loadAd();
+    }
+  }
+  //endregion
+
+  //region Common methods.
+
+  /**
+   * Checks whether or not the request parameters needed to load Facebook ads are null.
+   *
+   * @param context          an Android {@link Context}.
+   * @param serverParameters a {@link Bundle} containing server parameters needed to request ads
+   *                         from Facebook.
+   * @return {@code false} if any of the request parameters are null.
+   */
+  private static boolean isValidRequestParameters(Context context, Bundle serverParameters) {
+    if (context == null) {
+      Log.w(TAG, "Failed to request ad, Context is null.");
+      return false;
+    }
+
+    if (serverParameters == null) {
+      Log.w(TAG, "Failed to request ad, serverParameters is null.");
+      return false;
+    }
+
+    if (TextUtils.isEmpty(serverParameters.getString(PLACEMENT_PARAMETER))) {
+      Log.w(TAG, "Failed to request ad, placementId is null or empty.");
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Converts an {@link AdError} code to Google Mobile Ads SDK readable error code.
+   *
+   * @param adError the {@link AdError} to be converted.
+   * @return an {@link AdRequest} error code.
+   */
+  private int convertErrorCode(AdError adError) {
+    if (adError == null) {
+      return AdRequest.ERROR_CODE_INTERNAL_ERROR;
+    }
+    int errorCode = adError.getErrorCode();
+    switch (errorCode) {
+      case AdError.NETWORK_ERROR_CODE:
+      case AdError.SERVER_ERROR_CODE:
+        return AdRequest.ERROR_CODE_NETWORK_ERROR;
+      case AdError.NO_FILL_ERROR_CODE:
+        return AdRequest.ERROR_CODE_NO_FILL;
+      case AdError.LOAD_TOO_FREQUENTLY_ERROR_CODE:
+        return AdRequest.ERROR_CODE_INVALID_REQUEST;
+      case AdError.INTERNAL_ERROR_CODE:
+      default:
+        return AdRequest.ERROR_CODE_INTERNAL_ERROR;
+    }
+  }
+
+  private void buildAdRequest(MediationAdRequest adRequest) {
+    if (adRequest != null) {
+      AdSettings.setIsChildDirected((adRequest.taggedForChildDirectedTreatment()
+          == MediationAdRequest.TAG_FOR_CHILD_DIRECTED_TREATMENT_TRUE));
+    }
+  }
+  //endregion
+
+  //region Banner adapter utility classes.
+  private class BannerListener implements AdListener {
+    private BannerListener() {
+    }
+
+    @Override
+    public void onAdClicked(Ad ad) {
+      FacebookAdapter.this.mBannerListener.onAdClicked(FacebookAdapter.this);
+      FacebookAdapter.this.mBannerListener.onAdOpened(FacebookAdapter.this);
+      // The test Facebook ads leave the application when the ad is clicked. Assuming all
+      // the ads do the same, sending onAdLeftApplication callback when the ad is clicked.
+      FacebookAdapter.this.mBannerListener.onAdLeftApplication(FacebookAdapter.this);
+    }
+
+    @Override
+    public void onLoggingImpression(Ad ad) {
+      // Google Mobile Ads SDK does its own impression tracking for banner ads.
+    }
+
+    @Override
+    public void onAdLoaded(Ad ad) {
+      FacebookAdapter.this.mBannerListener.onAdLoaded(FacebookAdapter.this);
+    }
+
+    @Override
+    public void onError(Ad ad, AdError adError) {
+      String errorMessage = adError.getErrorMessage();
+      if (!TextUtils.isEmpty(errorMessage)) {
+        Log.w(TAG, errorMessage);
+      }
+      FacebookAdapter.this.mBannerListener.onAdFailedToLoad(
+          FacebookAdapter.this, convertErrorCode(adError));
+    }
+  }
+  //endregion
+
+  //region Interstitial adapter utility classes.
+  private class InterstitialListener implements InterstitialAdListener {
+    private InterstitialListener() {
+    }
+
+    @Override
+    public void onAdClicked(Ad ad) {
+      FacebookAdapter.this.mInterstitialListener.onAdClicked(FacebookAdapter.this);
+      // The test Facebook ads leave the application when the ad is clicked. Assuming all
+      // the ads do the same, sending onAdLeftApplication callback when the ad is clicked.
+      FacebookAdapter.this.mInterstitialListener.onAdLeftApplication(FacebookAdapter.this);
+    }
+
+    @Override
+    public void onLoggingImpression(Ad ad) {
+      // Google Mobile Ads SDK does its own impression tracking for interstitial ads.
+    }
+
+    @Override
+    public void onAdLoaded(Ad ad) {
+      FacebookAdapter.this.mInterstitialListener.onAdLoaded(FacebookAdapter.this);
+    }
+
+    @Override
+    public void onError(Ad ad, AdError adError) {
+      String errorMessage = adError.getErrorMessage();
+      if (!TextUtils.isEmpty(errorMessage)) {
+        Log.w(TAG, errorMessage);
+      }
+      FacebookAdapter.this.mInterstitialListener.onAdFailedToLoad(
+          FacebookAdapter.this, convertErrorCode(adError));
+    }
+
+    @Override
+    public void onInterstitialDismissed(Ad ad) {
+      FacebookAdapter.this.mInterstitialListener.onAdClosed(FacebookAdapter.this);
+    }
+
+    @Override
+    public void onInterstitialDisplayed(Ad ad) {
+      FacebookAdapter.this.mInterstitialListener.onAdOpened(FacebookAdapter.this);
+    }
+  }
+  //endregion
+
+  //region Rewarded video adapter utility classes.
+
+  /**
+   * A {@link RewardedVideoAdListener} used to listen to rewarded video ad events from Facebook
+   * SDK and forward to Google Mobile Ads SDK using {@link #mRewardedListener}
+   */
+  private class RewardedVideoListener implements RewardedVideoAdListener {
+    private RewardedVideoListener() {
+    }
+
+    @Override
+    public void onRewardedVideoCompleted() {
+      mRewardedListener.onVideoCompleted(FacebookAdapter.this);
+      // Facebook SDK doesn't provide a reward value. The publisher is expected to
+      // override the reward in AdMob UI.
+      mRewardedListener.onRewarded(FacebookAdapter.this, new FacebookReward());
+    }
+
+    @Override
+    public void onError(Ad ad, AdError adError) {
+      String errorMessage = adError.getErrorMessage();
+      if (!TextUtils.isEmpty(errorMessage)) {
+        Log.w(TAG, errorMessage);
+      }
+
+      mRewardedListener.onAdFailedToLoad(FacebookAdapter.this, convertErrorCode(adError));
+    }
+
+    @Override
+    public void onAdLoaded(Ad ad) {
+      mRewardedListener.onAdLoaded(FacebookAdapter.this);
+    }
+
+    @Override
+    public void onAdClicked(Ad ad) {
+      mRewardedListener.onAdClicked(FacebookAdapter.this);
+      mRewardedListener.onAdLeftApplication(FacebookAdapter.this);
+    }
+
+    @Override
+    public void onLoggingImpression(Ad ad) {
+      // Google Mobile Ads SDK does its own impression tracking for rewarded video ads.
+    }
+
+    @Override
+    public void onRewardedVideoClosed() {
+      mRewardedListener.onAdClosed(FacebookAdapter.this);
+    }
+  }
+
+  /**
+   * An implementation of {@link RewardItem} that will be given to the app when a Facebook reward
+   * is granted. Because the FAN SDK doesn't provide reward amounts and types, defaults are used
+   * here.
+   */
+  private class FacebookReward implements RewardItem {
+
+    @Override
+    public String getType() {
+      // Facebook SDK does not provide a reward type.
+      return "";
+    }
+
+    @Override
+    public int getAmount() {
+      // Facebook SDK does not provide reward amount, default to 1.
+      return 1;
+    }
+  }
+  //endregion
+
+  //region Native adapter utility methods and classes.
+  private class NativeListener implements AdListener, NativeAdListener {
+    private NativeAd mNativeAd;
+    private NativeMediationAdRequest mMediationAdRequest;
+
+    private NativeListener(NativeAd nativeAd, NativeMediationAdRequest mediationAdRequest) {
+      mNativeAd = nativeAd;
+      mMediationAdRequest = mediationAdRequest;
+    }
+
+    @Override
+    public void onAdClicked(Ad ad) {
+      FacebookAdapter.this.mNativeListener.onAdClicked(FacebookAdapter.this);
+      FacebookAdapter.this.mNativeListener.onAdOpened(FacebookAdapter.this);
+      // The test Facebook ads leave the application when the ad is clicked. Assuming all
+      // the ads do the same, sending onAdLeftApplication callback when the ad is clicked.
+      FacebookAdapter.this.mNativeListener.onAdLeftApplication(FacebookAdapter.this);
+    }
+
+    @Override
+    public void onLoggingImpression(Ad ad) {
+      if (mIsImpressionRecorded) {
+        Log.d(TAG, "Received onLoggingImpression callback for a native whose impression"
+            + " is already recorded. Ignoring the duplicate callback.");
+        return;
+      }
+      FacebookAdapter.this.mNativeListener.onAdImpression(FacebookAdapter.this);
+      mIsImpressionRecorded = true;
+    }
+
+    @Override
+    public void onAdLoaded(Ad ad) {
+      if (ad != mNativeAd) {
+        Log.w(TAG, "Ad loaded is not a native ad.");
+        FacebookAdapter.this.mNativeListener.onAdFailedToLoad(
+            FacebookAdapter.this, AdRequest.ERROR_CODE_INTERNAL_ERROR);
+        return;
+      }
+
+      NativeAdOptions options = mMediationAdRequest.getNativeAdOptions();
+      // We always convert the ad into an app install ad.
+      final AppInstallMapper mapper = new AppInstallMapper(mNativeAd, options);
+      mapper.mapNativeAd(new NativeAdMapperListener() {
+        @Override
+        public void onMappingSuccess() {
+          mNativeListener.onAdLoaded(FacebookAdapter.this, mapper);
+        }
+
+        @Override
+        public void onMappingFailed() {
+          mNativeListener.onAdFailedToLoad(FacebookAdapter.this,
+              AdRequest.ERROR_CODE_NO_FILL);
+        }
+      });
+    }
+
+    @Override
+    public void onError(Ad ad, AdError adError) {
+      String errorMessage = adError.getErrorMessage();
+      if (!TextUtils.isEmpty(errorMessage)) {
+        Log.w(TAG, errorMessage);
+      }
+      FacebookAdapter.this.mNativeListener.onAdFailedToLoad(
+          FacebookAdapter.this, convertErrorCode(adError));
+    }
+
+    @Override
+    public void onMediaDownloaded(Ad ad) {
+      Log.d(TAG, "onMediaDownloaded");
+    }
+  }
+
+  private com.facebook.ads.AdSize getAdSize(Context context, AdSize adSize) {
+    if (adSize.getWidth() == com.facebook.ads.AdSize.BANNER_320_50.getWidth()
+        && adSize.getHeight() == com.facebook.ads.AdSize.BANNER_320_50.getHeight()) {
+      return com.facebook.ads.AdSize.BANNER_320_50;
+    }
+
+    // adSize.getHeight will return -2 for smart banner. So we need to use
+    // adSize.getHeightInPixels here.
+    int heightInDip = pixelToDip(adSize.getHeightInPixels(context));
+    if (heightInDip == com.facebook.ads.AdSize.BANNER_HEIGHT_50.getHeight()) {
+      return com.facebook.ads.AdSize.BANNER_HEIGHT_50;
+    }
+
+    if (heightInDip == com.facebook.ads.AdSize.BANNER_HEIGHT_90.getHeight()) {
+      return com.facebook.ads.AdSize.BANNER_HEIGHT_90;
+    }
+
+    if (heightInDip == com.facebook.ads.AdSize.RECTANGLE_HEIGHT_250.getHeight()) {
+      return com.facebook.ads.AdSize.RECTANGLE_HEIGHT_250;
+    }
+    return null;
+  }
+
+  private int pixelToDip(int pixel) {
+    DisplayMetrics displayMetrics = Resources.getSystem().getDisplayMetrics();
+    return Math.round(pixel / displayMetrics.density);
+  }
+
+  public static class GMSVersionUpdateTask extends AsyncTask<Void, Void, Integer> {
+
+    public Context context;
+    GMSVersionUpdateTask(Context context) {
+      this.context = context;
+    }
+
+    public interface OnGMSUpdateListener {
+      void OnGMSVersionUpdate();
+    }
+
+    private OnGMSUpdateListener listener;
+
+    private void Task(OnGMSUpdateListener listener) {
+      this.listener = listener;
+    }
+
+    @Override
+    protected Integer doInBackground(Void... voids) {
+      try {
+        return context.getPackageManager().getPackageInfo("com.google.android.gms", 0).versionCode;
+      } catch (PackageManager.NameNotFoundException e) {
+        return 0;
+      }
+    }
+
+    @Override
+    protected void onPostExecute(Integer result) {
+      gmsVersion.set(result);
+      if (this.listener != null) {
+        listener.OnGMSVersionUpdate();
+      }
+    }
+  }
+
+  /**
+   * The {@link AppInstallMapper} class is used to map Facebook native ads to Google Mobile Ads'
+   * native app install ads.
+   */
+  class AppInstallMapper extends NativeAppInstallAdMapper {
 
     /**
-     * Mediation rewarded video ad listener used to forward reward-based video ad events from
-     * Facebook SDK to Google Mobile Ads SDK.
+     * The Facebook native ad to be mapped.
      */
-    private MediationRewardedVideoAdListener mRewardedListener;
-    private MediationNativeListener mNativeListener;
-    private AdView mAdView;
-    private RelativeLayout mWrappedAdView;
-    private InterstitialAd mInterstitialAd;
-
-    /**
-     * Facebook rewarded video ad instance.
-     */
-    private String mPlacementId;
-    private RewardedVideoAd mRewardedVideoAd;
-
-    private Context mContext;
-
     private NativeAd mNativeAd;
 
     /**
-     * Flag to determine whether or not the rewarded video adapter has been initialized.
+     * Google Mobile Ads native ad options.
      */
-    private boolean mIsInitialized;
+    private NativeAdOptions mNativeAdOptions;
 
     /**
-     * Flag to determine whether or not an impression callback from Facebook SDK has already been
-     * sent to the Google Mobile Ads SDK.
-     */
-    private boolean mIsImpressionRecorded;
-
-    /**
-     * A Facebook {@link MediaView} used to show native ad media content.
-     */
-    private MediaView mMediaView;
-
-    /**
-     * Flag to determine whether or not the Audience Network SDK has been initialized.
-     */
-    private AtomicBoolean mIsSdkInitialized = new AtomicBoolean(false);
-
-    //region MediationAdapter implementation.
-    @Override
-    public void onDestroy() {
-        if (mAdView != null) {
-            mAdView.destroy();
-        }
-        if (mInterstitialAd != null) {
-            mInterstitialAd.destroy();
-        }
-        if (mNativeAd != null) {
-            mNativeAd.unregisterView();
-            mNativeAd.destroy();
-        }
-        if (mMediaView != null) {
-            mMediaView.destroy();
-        }
-        if (mRewardedVideoAd != null) {
-            mRewardedVideoAd.destroy();
-        }
-    }
-
-    @Override
-    public void onPause() {
-        // Do nothing.
-    }
-
-    @Override
-    public void onResume() {
-        // Do nothing.
-    }
-    //endregion
-
-    //region MediationBannerAdapter implementation.
-    @Override
-    public void requestBannerAd(Context context,
-                                MediationBannerListener listener,
-                                Bundle serverParameters,
-                                AdSize adSize,
-                                MediationAdRequest adRequest,
-                                Bundle mediationExtras) {
-        mBannerListener = listener;
-        if (!mIsSdkInitialized.getAndSet(true)) {
-            AudienceNetworkAds.initialize(context);
-        }
-        if (!isValidRequestParameters(context, serverParameters)) {
-            mBannerListener.onAdFailedToLoad(
-                    FacebookAdapter.this, AdRequest.ERROR_CODE_INVALID_REQUEST);
-            return;
-        }
-        if (adSize == null) {
-            Log.w(TAG, "Fail to request banner ad, adSize is null");
-            mBannerListener.onAdFailedToLoad(this, AdRequest.ERROR_CODE_INVALID_REQUEST);
-            return;
-        }
-
-        String placementId = serverParameters.getString(PLACEMENT_PARAMETER);
-
-        com.facebook.ads.AdSize facebookAdSize = getAdSize(context, adSize);
-        if (facebookAdSize == null) {
-            Log.w(TAG,
-                    "The input ad size " + adSize.toString() + " is not supported at this moment.");
-            mBannerListener.onAdFailedToLoad(this, AdRequest.ERROR_CODE_NO_FILL);
-            return;
-        }
-        mAdView = new AdView(context, placementId, facebookAdSize);
-        mAdView.setAdListener(new BannerListener());
-        buildAdRequest(adRequest);
-        RelativeLayout.LayoutParams adViewLayoutParams = new RelativeLayout.LayoutParams(
-                adSize.getWidthInPixels(context), adSize.getHeightInPixels(context));
-        mWrappedAdView = new RelativeLayout(context);
-        mAdView.setLayoutParams(adViewLayoutParams);
-        mWrappedAdView.addView(mAdView);
-        if (gmsVersion.get() == 0) {
-            GMSVersionUpdateTask gmsVersionUpdateTask = new GMSVersionUpdateTask(context);
-             gmsVersionUpdateTask.Task(new GMSVersionUpdateTask.OnGMSUpdateListener() {
-                @Override
-                public void OnGMSVersionUpdate() {
-                    AdSettings.setMediationService("ADMOB_" + gmsVersion);
-                    mAdView.loadAd();
-                }
-            });
-            gmsVersionUpdateTask.execute();
-        } else {
-            AdSettings.setMediationService("ADMOB_" + gmsVersion);
-            mAdView.loadAd();
-        }
-    }
-
-    @Override
-    public View getBannerView() {
-        return mWrappedAdView;
-    }
-    //endregion
-
-    //region MediationInterstitialAdapter implementation.
-    @Override
-    public void requestInterstitialAd(Context context,
-                                      MediationInterstitialListener listener,
-                                      Bundle serverParameters,
-                                      MediationAdRequest adRequest,
-                                      Bundle mediationExtras) {
-        mInterstitialListener = listener;
-        if (!mIsSdkInitialized.getAndSet(true)) {
-            AudienceNetworkAds.initialize(context);
-        }
-        if (!isValidRequestParameters(context, serverParameters)) {
-            mInterstitialListener.onAdFailedToLoad(this, AdRequest.ERROR_CODE_INVALID_REQUEST);
-            return;
-        }
-
-        String placementId = serverParameters.getString(PLACEMENT_PARAMETER);
-
-        mInterstitialAd = new InterstitialAd(context, placementId);
-        mInterstitialAd.setAdListener(new InterstitialListener());
-        buildAdRequest(adRequest);
-        if (gmsVersion.get() == 0) {
-            GMSVersionUpdateTask gmsVersionUpdateTask = new GMSVersionUpdateTask(context);
-             gmsVersionUpdateTask.Task(new GMSVersionUpdateTask.OnGMSUpdateListener() {
-                @Override
-                public void OnGMSVersionUpdate() {
-                    AdSettings.setMediationService("ADMOB_" + gmsVersion);
-                    mInterstitialAd.loadAd();
-                }
-            });
-            gmsVersionUpdateTask.execute();
-        } else {
-            AdSettings.setMediationService("ADMOB_" + gmsVersion);
-            mInterstitialAd.loadAd();
-        }
-    }
-
-    @Override
-    public void showInterstitial() {
-        if (mInterstitialAd.isAdLoaded()) {
-            mInterstitialAd.show();
-        }
-    }
-    //endregion
-
-    //region MediationRewardedVideoAdAdapter implementation.
-    @Override
-    public void initialize(Context context,
-                           MediationAdRequest mediationAdRequest,
-                           String unused,
-                           MediationRewardedVideoAdListener mediationRewardedVideoAdListener,
-                           Bundle serverParameters,
-                           Bundle networkExtras) {
-        mContext = context;
-        if (!mIsSdkInitialized.getAndSet(true)) {
-            AudienceNetworkAds.initialize(context);
-        }
-        mRewardedListener = mediationRewardedVideoAdListener;
-        if (!isValidRequestParameters(context, serverParameters)) {
-            mRewardedListener.onAdFailedToLoad(this, AdRequest.ERROR_CODE_INVALID_REQUEST);
-            return;
-        }
-
-        mPlacementId = serverParameters.getString(PLACEMENT_PARAMETER);
-        mIsInitialized = true;
-        mRewardedListener.onInitializationSucceeded(this);
-    }
-
-    @Override
-    public void loadAd(MediationAdRequest mediationAdRequest,
-                       Bundle serverParameters,
-                       Bundle networkExtras) {
-        if (mRewardedVideoAd == null) {
-            mRewardedVideoAd = new RewardedVideoAd(mContext, mPlacementId);
-            mRewardedVideoAd.setAdListener(new RewardedVideoListener());
-        }
-
-        if (mRewardedVideoAd.isAdLoaded()) {
-            mRewardedListener.onAdLoaded(this);
-        } else {
-            buildAdRequest(mediationAdRequest);
-            if (gmsVersion.get() == 0) {
-                GMSVersionUpdateTask gmsVersionUpdateTask = new GMSVersionUpdateTask(mContext);
-                 gmsVersionUpdateTask.Task(new GMSVersionUpdateTask.OnGMSUpdateListener() {
-                    @Override
-                    public void OnGMSVersionUpdate() {
-                        AdSettings.setMediationService("ADMOB_" + gmsVersion);
-                        mRewardedVideoAd.loadAd(true);
-                    }
-                });
-                gmsVersionUpdateTask.execute();
-            } else {
-                AdSettings.setMediationService("ADMOB_" + gmsVersion);
-                mRewardedVideoAd.loadAd(true);
-            }
-        }
-    }
-
-    @Override
-    public void showVideo() {
-        if (mRewardedVideoAd != null && mRewardedVideoAd.isAdLoaded()) {
-            mRewardedVideoAd.show();
-            // Facebook's rewarded video listener does not have an equivalent callback for
-            // onAdOpened() but an ad is shown immediately after calling show(), so sending an
-            // onAdOpened callback.
-            mRewardedListener.onAdOpened(FacebookAdapter.this);
-            mRewardedListener.onVideoStarted(FacebookAdapter.this);
-        } else {
-            // No ads to show, but already sent onAdLoaded. Log a warning and send ad opened and
-            // ad closed callbacks.
-            Log.w(TAG, "No ads to show.");
-            if (mRewardedListener != null) {
-                mRewardedListener.onAdOpened(this);
-                mRewardedListener.onAdClosed(this);
-            }
-        }
-    }
-
-    @Override
-    public boolean isInitialized() {
-        return mIsInitialized;
-    }
-    //endregion
-
-    //region MediationNativeAdapter implementation.
-    @Override
-    public void requestNativeAd(Context context,
-                                MediationNativeListener listener,
-                                Bundle serverParameters,
-                                NativeMediationAdRequest mediationAdRequest,
-                                Bundle mediationExtras) {
-        mNativeListener = listener;
-        if (!mIsSdkInitialized.getAndSet(true)) {
-            AudienceNetworkAds.initialize(context);
-        }
-        if (!isValidRequestParameters(context, serverParameters)) {
-            mNativeListener.onAdFailedToLoad(this, AdRequest.ERROR_CODE_INVALID_REQUEST);
-            return;
-        }
-
-        // Verify that the request is for both app install and content ads.
-        if (!(mediationAdRequest.isAppInstallAdRequested()
-                && mediationAdRequest.isContentAdRequested())) {
-            Log.w(TAG, "Failed to request native ad. Both app install and content ad should be "
-                    + "requested");
-            mNativeListener.onAdFailedToLoad(this, AdRequest.ERROR_CODE_INVALID_REQUEST);
-            return;
-        }
-
-        String placementId = serverParameters.getString(PLACEMENT_PARAMETER);
-
-        mMediaView = new MediaView(context);
-
-        mNativeAd = new NativeAd(context, placementId);
-        mNativeAd.setAdListener(new NativeListener(mNativeAd, mediationAdRequest));
-        buildAdRequest(mediationAdRequest);
-        if (gmsVersion.get() == 0) {
-            GMSVersionUpdateTask gmsVersionUpdateTask = new GMSVersionUpdateTask(context);
-             gmsVersionUpdateTask.Task(new GMSVersionUpdateTask.OnGMSUpdateListener() {
-                @Override
-                public void OnGMSVersionUpdate() {
-                    AdSettings.setMediationService("ADMOB_" + gmsVersion);
-                    mNativeAd.loadAd();
-                }
-            });
-            gmsVersionUpdateTask.execute();
-        } else {
-            AdSettings.setMediationService("ADMOB_" + gmsVersion);
-            mNativeAd.loadAd();
-        }
-    }
-    //endregion
-
-    //region Common methods.
-
-    /**
-     * Checks whether or not the request parameters needed to load Facebook ads are null.
+     * Default constructor for {@link AppInstallMapper}.
      *
-     * @param context          an Android {@link Context}.
-     * @param serverParameters a {@link Bundle} containing server parameters needed to request ads
-     *                         from Facebook.
-     * @return {@code false} if any of the request parameters are null.
+     * @param nativeAd  The Facebook native ad to be mapped.
+     * @param adOptions {@link NativeAdOptions} containing the preferences to be used when
+     *                  mapping the native ad.
      */
-    private static boolean isValidRequestParameters(Context context, Bundle serverParameters) {
-        if (context == null) {
-            Log.w(TAG, "Failed to request ad, Context is null.");
-            return false;
-        }
-
-        if (serverParameters == null) {
-            Log.w(TAG, "Failed to request ad, serverParameters is null.");
-            return false;
-        }
-
-        if (TextUtils.isEmpty(serverParameters.getString(PLACEMENT_PARAMETER))) {
-            Log.w(TAG, "Failed to request ad, placementId is null or empty.");
-            return false;
-        }
-        return true;
+    public AppInstallMapper(NativeAd nativeAd, NativeAdOptions adOptions) {
+      AppInstallMapper.this.mNativeAd = nativeAd;
+      AppInstallMapper.this.mNativeAdOptions = adOptions;
     }
 
     /**
-     * Converts an {@link AdError} code to Google Mobile Ads SDK readable error code.
+     * This method will map the Facebook {@link #mNativeAd} to this mapper and send a success
+     * callback if the mapping was successful or a failure callback if the mapping was
+     * unsuccessful.
      *
-     * @param adError the {@link AdError} to be converted.
-     * @return an {@link AdRequest} error code.
+     * @param mapperListener used to send success/failure callbacks when mapping is done.
      */
-    private int convertErrorCode(AdError adError) {
-        if (adError == null) {
-            return AdRequest.ERROR_CODE_INTERNAL_ERROR;
+    public void mapNativeAd(NativeAdMapperListener mapperListener) {
+      if (!containsRequiredFieldsForNativeAppInstallAd(mNativeAd)) {
+        Log.w(TAG, "Ad from Facebook doesn't have all assets required for the app install"
+            + " format.");
+        mapperListener.onMappingFailed();
+        return;
+      }
+
+      // Map all required assets (headline, one image, body, icon and call to
+      // action).
+      setHeadline(mNativeAd.getAdHeadline());
+      List<com.google.android.gms.ads.formats.NativeAd.Image> images = new ArrayList<>();
+      images.add(new FacebookAdapterNativeAdImage(
+          Uri.parse(mNativeAd.getAdCoverImage().toString())));
+      setImages(images);
+      setBody(mNativeAd.getAdBodyText());
+      setIcon(new FacebookAdapterNativeAdImage(Uri.parse(mNativeAd.getAdIcon().toString())));
+      setCallToAction(mNativeAd.getAdCallToAction());
+
+      mMediaView.setListener(new MediaViewListener() {
+        @Override
+        public void onPlay(MediaView mediaView) {
+          // Google Mobile Ads SDK doesn't have a matching event. Do nothing.
         }
-        int errorCode = adError.getErrorCode();
-        switch (errorCode) {
-            case AdError.NETWORK_ERROR_CODE:
-            case AdError.SERVER_ERROR_CODE:
-                return AdRequest.ERROR_CODE_NETWORK_ERROR;
-            case AdError.NO_FILL_ERROR_CODE:
-                return AdRequest.ERROR_CODE_NO_FILL;
-            case AdError.LOAD_TOO_FREQUENTLY_ERROR_CODE:
-                return AdRequest.ERROR_CODE_INVALID_REQUEST;
-            case AdError.INTERNAL_ERROR_CODE:
+
+        @Override
+        public void onVolumeChange(MediaView mediaView, float v) {
+          // Google Mobile Ads SDK doesn't have a matching event. Do nothing.
+        }
+
+        @Override
+        public void onPause(MediaView mediaView) {
+          // Google Mobile Ads SDK doesn't have a matching event. Do nothing.
+        }
+
+        @Override
+        public void onComplete(MediaView mediaView) {
+          if (FacebookAdapter.this.mNativeListener != null) {
+            FacebookAdapter.this.mNativeListener.onVideoEnd(FacebookAdapter.this);
+          }
+        }
+
+        @Override
+        public void onEnterFullscreen(MediaView mediaView) {
+          // Google Mobile Ads SDK doesn't have a matching event. Do nothing.
+        }
+
+        @Override
+        public void onExitFullscreen(MediaView mediaView) {
+          // Google Mobile Ads SDK doesn't have a matching event. Do nothing.
+        }
+
+        @Override
+        public void onFullscreenBackground(MediaView mediaView) {
+          // Google Mobile Ads SDK doesn't have a matching event. Do nothing.
+        }
+
+        @Override
+        public void onFullscreenForeground(MediaView mediaView) {
+          // Google Mobile Ads SDK doesn't have a matching event. Do nothing.
+        }
+      });
+
+      // Because the FAN SDK doesn't offer a way to determine whether a native ad contains
+      // a video asset or not, the adapter always returns a MediaView and claims to have
+      // video content.
+      setMediaView(mMediaView);
+      setHasVideoContent(true);
+
+      // Map the optional assets.
+      Double starRating = getRating(mNativeAd.getAdStarRating());
+      if (starRating != null) {
+        setStarRating(starRating);
+      }
+
+      // Pass all the assets not supported by Google as extras.
+      Bundle extras = new Bundle();
+      extras.putCharSequence(KEY_ID, mNativeAd.getId());
+      extras.putCharSequence(KEY_SOCIAL_CONTEXT_ASSET, mNativeAd.getAdSocialContext());
+      setExtras(extras);
+
+      mapperListener.onMappingSuccess();
+    }
+
+    /**
+     * This method will check whether or not the given Facebook native ad contains all the
+     * necessary fields for it to be mapped to Google Mobile Ads' native app install ad.
+     *
+     * @param nativeAd Facebook native ad.
+     * @return {@code true} if the given ad contains all the necessary fields, {@link false}
+     * otherwise.
+     */
+    private boolean containsRequiredFieldsForNativeAppInstallAd(NativeAd nativeAd) {
+      return ((nativeAd.getAdHeadline() != null) && (nativeAd.getAdCoverImage() != null)
+          && (nativeAd.getAdBodyText() != null) && (nativeAd.getAdIcon() != null)
+          && (nativeAd.getAdCallToAction() != null) && (mMediaView != null));
+    }
+
+    @Override
+    public void trackViews(View view,
+        Map<String, View> clickableAssetViews,
+        Map<String, View> nonClickableAssetViews) {
+
+      ViewGroup adView = (ViewGroup) view;
+      // Find the overlay view in the given ad view. The overlay view will always be the
+      // top most view in the hierarchy.
+      View overlayView = adView.getChildAt(adView.getChildCount() - 1);
+      if (overlayView instanceof FrameLayout) {
+        NativeAdLayout nativeAdLayout = new NativeAdLayout(view.getContext());
+        ((FrameLayout) overlayView).addView(nativeAdLayout);
+
+        // Create and add Facebook's AdOptions to the overlay view.
+        AdOptionsView adOptionsView = new AdOptionsView(view.getContext(), mNativeAd,
+            nativeAdLayout);
+
+        ((ViewGroup) overlayView).addView(adOptionsView);
+        // We know that the overlay view is a FrameLayout, so we get the FrameLayout's
+        // LayoutParams from the AdOptionsView.
+        FrameLayout.LayoutParams params =
+            (FrameLayout.LayoutParams) adOptionsView.getLayoutParams();
+        if (mNativeAdOptions != null) {
+          switch (mNativeAdOptions.getAdChoicesPlacement()) {
+            case NativeAdOptions.ADCHOICES_TOP_LEFT:
+              params.gravity = Gravity.TOP | Gravity.LEFT;
+              break;
+            case NativeAdOptions.ADCHOICES_BOTTOM_RIGHT:
+              params.gravity = Gravity.BOTTOM | Gravity.RIGHT;
+              break;
+            case NativeAdOptions.ADCHOICES_BOTTOM_LEFT:
+              params.gravity = Gravity.BOTTOM | Gravity.LEFT;
+              break;
+            case NativeAdOptions.ADCHOICES_TOP_RIGHT:
             default:
-                return AdRequest.ERROR_CODE_INTERNAL_ERROR;
+              params.gravity = Gravity.TOP | Gravity.RIGHT;
+          }
+        } else {
+          // Default to top right if native ad options are not provided.
+          params.gravity = Gravity.TOP | Gravity.RIGHT;
         }
+        adView.requestLayout();
+      } else {
+        AdOptionsView adOptionsView = new AdOptionsView(view.getContext(), mNativeAd, null);
+        this.setAdChoicesContent(adOptionsView);
+      }
+
+      // Facebook does its own impression tracking.
+      setOverrideImpressionRecording(true);
+
+      // Facebook does its own click handling.
+      setOverrideClickHandling(true);
+      ImageView iconview = null;
+
+      ArrayList<View> assetViews = new ArrayList<>();
+      for (Map.Entry<String, View> clickableAssets : clickableAssetViews.entrySet()) {
+        assetViews.add(clickableAssets.getValue());
+
+        if (clickableAssets.getKey().equals(NativeAppInstallAd.ASSET_ICON) ||
+            clickableAssets.getKey().equals(UnifiedNativeAdAssetNames.ASSET_ICON)) {
+          iconview = (ImageView) clickableAssets.getValue();
+        }
+
+      }
+
+      mNativeAd.registerViewForInteraction(view, mMediaView, iconview, assetViews);
     }
 
-    private void buildAdRequest(MediationAdRequest adRequest) {
-        if (adRequest != null) {
-            AdSettings.setIsChildDirected((adRequest.taggedForChildDirectedTreatment()
-                    == MediationAdRequest.TAG_FOR_CHILD_DIRECTED_TREATMENT_TRUE));
-        }
-    }
-    //endregion
 
-    //region Banner adapter utility classes.
-    private class BannerListener implements AdListener {
-        private BannerListener() {
-        }
+    @Override
+    public void untrackView(View view) {
+      super.untrackView(view);
+      // Called when the native ad view no longer needs tracking. Remove any previously
+      // added trackers.
 
-        @Override
-        public void onAdClicked(Ad ad) {
-            FacebookAdapter.this.mBannerListener.onAdClicked(FacebookAdapter.this);
-            FacebookAdapter.this.mBannerListener.onAdOpened(FacebookAdapter.this);
-            // The test Facebook ads leave the application when the ad is clicked. Assuming all
-            // the ads do the same, sending onAdLeftApplication callback when the ad is clicked.
-            FacebookAdapter.this.mBannerListener.onAdLeftApplication(FacebookAdapter.this);
-        }
+      ViewGroup adView = (ViewGroup) view;
+      // Find the overlay view in the given ad view. The overlay view will always be the
+      // top most view in the hierarchy.
+      View overlayView = adView.getChildAt(adView.getChildCount() - 1);
+      if (overlayView instanceof FrameLayout) {
+        ((FrameLayout) overlayView).removeAllViews();
+      }
 
-        @Override
-        public void onLoggingImpression(Ad ad) {
-            // Google Mobile Ads SDK does its own impression tracking for banner ads.
-        }
-
-        @Override
-        public void onAdLoaded(Ad ad) {
-            FacebookAdapter.this.mBannerListener.onAdLoaded(FacebookAdapter.this);
-        }
-
-        @Override
-        public void onError(Ad ad, AdError adError) {
-            String errorMessage = adError.getErrorMessage();
-            if (!TextUtils.isEmpty(errorMessage)) {
-                Log.w(TAG, errorMessage);
-            }
-            FacebookAdapter.this.mBannerListener.onAdFailedToLoad(
-                    FacebookAdapter.this, convertErrorCode(adError));
-        }
-    }
-    //endregion
-
-    //region Interstitial adapter utility classes.
-    private class InterstitialListener implements InterstitialAdListener {
-        private InterstitialListener() {
-        }
-
-        @Override
-        public void onAdClicked(Ad ad) {
-            FacebookAdapter.this.mInterstitialListener.onAdClicked(FacebookAdapter.this);
-            // The test Facebook ads leave the application when the ad is clicked. Assuming all
-            // the ads do the same, sending onAdLeftApplication callback when the ad is clicked.
-            FacebookAdapter.this.mInterstitialListener.onAdLeftApplication(FacebookAdapter.this);
-        }
-
-        @Override
-        public void onLoggingImpression(Ad ad) {
-            // Google Mobile Ads SDK does its own impression tracking for interstitial ads.
-        }
-
-        @Override
-        public void onAdLoaded(Ad ad) {
-            FacebookAdapter.this.mInterstitialListener.onAdLoaded(FacebookAdapter.this);
-        }
-
-        @Override
-        public void onError(Ad ad, AdError adError) {
-            String errorMessage = adError.getErrorMessage();
-            if (!TextUtils.isEmpty(errorMessage)) {
-                Log.w(TAG, errorMessage);
-            }
-            FacebookAdapter.this.mInterstitialListener.onAdFailedToLoad(
-                    FacebookAdapter.this, convertErrorCode(adError));
-        }
-
-        @Override
-        public void onInterstitialDismissed(Ad ad) {
-            FacebookAdapter.this.mInterstitialListener.onAdClosed(FacebookAdapter.this);
-        }
-
-        @Override
-        public void onInterstitialDisplayed(Ad ad) {
-            FacebookAdapter.this.mInterstitialListener.onAdOpened(FacebookAdapter.this);
-        }
-    }
-    //endregion
-
-    //region Rewarded video adapter utility classes.
-
-    /**
-     * A {@link RewardedVideoAdListener} used to listen to rewarded video ad events from Facebook
-     * SDK and forward to Google Mobile Ads SDK using {@link #mRewardedListener}
-     */
-    private class RewardedVideoListener implements RewardedVideoAdListener {
-        private RewardedVideoListener() {
-        }
-
-        @Override
-        public void onRewardedVideoCompleted() {
-            mRewardedListener.onVideoCompleted(FacebookAdapter.this);
-            // Facebook SDK doesn't provide a reward value. The publisher is expected to
-            // override the reward in AdMob UI.
-            mRewardedListener.onRewarded(FacebookAdapter.this, new FacebookReward());
-        }
-
-        @Override
-        public void onError(Ad ad, AdError adError) {
-            String errorMessage = adError.getErrorMessage();
-            if (!TextUtils.isEmpty(errorMessage)) {
-                Log.w(TAG, errorMessage);
-            }
-
-            mRewardedListener.onAdFailedToLoad(FacebookAdapter.this, convertErrorCode(adError));
-        }
-
-        @Override
-        public void onAdLoaded(Ad ad) {
-            mRewardedListener.onAdLoaded(FacebookAdapter.this);
-        }
-
-        @Override
-        public void onAdClicked(Ad ad) {
-            mRewardedListener.onAdClicked(FacebookAdapter.this);
-            mRewardedListener.onAdLeftApplication(FacebookAdapter.this);
-        }
-
-        @Override
-        public void onLoggingImpression(Ad ad) {
-            // Google Mobile Ads SDK does its own impression tracking for rewarded video ads.
-        }
-
-        @Override
-        public void onRewardedVideoClosed() {
-            mRewardedListener.onAdClosed(FacebookAdapter.this);
-        }
+      mNativeAd.unregisterView();
     }
 
     /**
-     * An implementation of {@link RewardItem} that will be given to the app when a Facebook reward
-     * is granted. Because the FAN SDK doesn't provide reward amounts and types, defaults are used
-     * here.
+     * Convert rating to a scale of 1 to 5.
      */
-    private class FacebookReward implements RewardItem {
-
-        @Override
-        public String getType() {
-            // Facebook SDK does not provide a reward type.
-            return "";
-        }
-
-        @Override
-        public int getAmount() {
-            // Facebook SDK does not provide reward amount, default to 1.
-            return 1;
-        }
-    }
-    //endregion
-
-    //region Native adapter utility methods and classes.
-    private class NativeListener implements AdListener, NativeAdListener {
-        private NativeAd mNativeAd;
-        private NativeMediationAdRequest mMediationAdRequest;
-
-        private NativeListener(NativeAd nativeAd, NativeMediationAdRequest mediationAdRequest) {
-            mNativeAd = nativeAd;
-            mMediationAdRequest = mediationAdRequest;
-        }
-
-        @Override
-        public void onAdClicked(Ad ad) {
-            FacebookAdapter.this.mNativeListener.onAdClicked(FacebookAdapter.this);
-            FacebookAdapter.this.mNativeListener.onAdOpened(FacebookAdapter.this);
-            // The test Facebook ads leave the application when the ad is clicked. Assuming all
-            // the ads do the same, sending onAdLeftApplication callback when the ad is clicked.
-            FacebookAdapter.this.mNativeListener.onAdLeftApplication(FacebookAdapter.this);
-        }
-
-        @Override
-        public void onLoggingImpression(Ad ad) {
-            if (mIsImpressionRecorded) {
-                Log.d(TAG, "Received onLoggingImpression callback for a native whose impression"
-                        + " is already recorded. Ignoring the duplicate callback.");
-                return;
-            }
-            FacebookAdapter.this.mNativeListener.onAdImpression(FacebookAdapter.this);
-            mIsImpressionRecorded = true;
-        }
-
-        @Override
-        public void onAdLoaded(Ad ad) {
-            if (ad != mNativeAd) {
-                Log.w(TAG, "Ad loaded is not a native ad.");
-                FacebookAdapter.this.mNativeListener.onAdFailedToLoad(
-                        FacebookAdapter.this, AdRequest.ERROR_CODE_INTERNAL_ERROR);
-                return;
-            }
-
-            NativeAdOptions options = mMediationAdRequest.getNativeAdOptions();
-            // We always convert the ad into an app install ad.
-            final AppInstallMapper mapper = new AppInstallMapper(mNativeAd, options);
-            mapper.mapNativeAd(new NativeAdMapperListener() {
-                @Override
-                public void onMappingSuccess() {
-                    mNativeListener.onAdLoaded(FacebookAdapter.this, mapper);
-                }
-
-                @Override
-                public void onMappingFailed() {
-                    mNativeListener.onAdFailedToLoad(FacebookAdapter.this,
-                            AdRequest.ERROR_CODE_NO_FILL);
-                }
-            });
-        }
-
-        @Override
-        public void onError(Ad ad, AdError adError) {
-            String errorMessage = adError.getErrorMessage();
-            if (!TextUtils.isEmpty(errorMessage)) {
-                Log.w(TAG, errorMessage);
-            }
-            FacebookAdapter.this.mNativeListener.onAdFailedToLoad(
-                    FacebookAdapter.this, convertErrorCode(adError));
-        }
-
-        @Override
-        public void onMediaDownloaded(Ad ad) {
-            Log.d(TAG, "onMediaDownloaded");
-        }
-    }
-
-    private com.facebook.ads.AdSize getAdSize(Context context, AdSize adSize) {
-        if (adSize.getWidth() == com.facebook.ads.AdSize.BANNER_320_50.getWidth()
-                && adSize.getHeight() == com.facebook.ads.AdSize.BANNER_320_50.getHeight()) {
-            return com.facebook.ads.AdSize.BANNER_320_50;
-        }
-
-        // adSize.getHeight will return -2 for smart banner. So we need to use
-        // adSize.getHeightInPixels here.
-        int heightInDip = pixelToDip(adSize.getHeightInPixels(context));
-        if (heightInDip == com.facebook.ads.AdSize.BANNER_HEIGHT_50.getHeight()) {
-            return com.facebook.ads.AdSize.BANNER_HEIGHT_50;
-        }
-
-        if (heightInDip == com.facebook.ads.AdSize.BANNER_HEIGHT_90.getHeight()) {
-            return com.facebook.ads.AdSize.BANNER_HEIGHT_90;
-        }
-
-        if (heightInDip == com.facebook.ads.AdSize.RECTANGLE_HEIGHT_250.getHeight()) {
-            return com.facebook.ads.AdSize.RECTANGLE_HEIGHT_250;
-        }
+    private Double getRating(NativeAd.Rating rating) {
+      if (rating == null) {
         return null;
+      }
+      return (MAX_STAR_RATING * rating.getValue()) / rating.getScale();
     }
+  }
 
-    private int pixelToDip(int pixel) {
-        DisplayMetrics displayMetrics = Resources.getSystem().getDisplayMetrics();
-        return Math.round(pixel / displayMetrics.density);
-    }
+  /**
+   * The {@link FacebookAdapterNativeAdImage} class is a subclass of
+   * {@link com.google.android.gms.ads.formats.NativeAd.Image} used by the {@link FacebookAdapter}
+   * to create images for native ads.
+   */
+  private class FacebookAdapterNativeAdImage extends
+      com.google.android.gms.ads.formats.NativeAd.Image {
 
-    public static class GMSVersionUpdateTask extends AsyncTask<Void, Void, Integer> {
+    /**
+     * A drawable for the Image.
+     */
+    private Drawable mDrawable;
 
-        public Context context;
-        GMSVersionUpdateTask(Context context) {
-            this.context = context;
-        }
+    /**
+     * An Uri from which the image can be obtained.
+     */
+    private Uri mUri;
 
-        public interface OnGMSUpdateListener {
-            void OnGMSVersionUpdate();
-        }
-
-        private OnGMSUpdateListener listener;
-
-        private void Task(OnGMSUpdateListener listener) {
-            this.listener = listener;
-        }
-
-        @Override
-        protected Integer doInBackground(Void... voids) {
-            try {
-                return context.getPackageManager().getPackageInfo("com.google.android.gms", 0).versionCode;
-            } catch (PackageManager.NameNotFoundException e) {
-                return 0;
-            }
-        }
-
-        @Override
-        protected void onPostExecute(Integer result) {
-            gmsVersion.set(result);
-            if (this.listener != null) {
-                listener.OnGMSVersionUpdate();
-            }
-        }
+    /**
+     * Default constructor for {@link FacebookAdapterNativeAdImage}, requires an {@link Uri}.
+     *
+     * @param uri required to initialize.
+     */
+    public FacebookAdapterNativeAdImage(Uri uri) {
+      this.mUri = uri;
     }
 
     /**
-     * The {@link AppInstallMapper} class is used to map Facebook native ads to Google Mobile Ads'
-     * native app install ads.
+     * @param drawable set to {@link #mDrawable}.
      */
-    class AppInstallMapper extends NativeAppInstallAdMapper {
-
-        /**
-         * The Facebook native ad to be mapped.
-         */
-        private NativeAd mNativeAd;
-
-        /**
-         * Google Mobile Ads native ad options.
-         */
-        private NativeAdOptions mNativeAdOptions;
-
-        /**
-         * Default constructor for {@link AppInstallMapper}.
-         *
-         * @param nativeAd  The Facebook native ad to be mapped.
-         * @param adOptions {@link NativeAdOptions} containing the preferences to be used when
-         *                  mapping the native ad.
-         */
-        public AppInstallMapper(NativeAd nativeAd, NativeAdOptions adOptions) {
-            AppInstallMapper.this.mNativeAd = nativeAd;
-            AppInstallMapper.this.mNativeAdOptions = adOptions;
-        }
-
-        /**
-         * This method will map the Facebook {@link #mNativeAd} to this mapper and send a success
-         * callback if the mapping was successful or a failure callback if the mapping was
-         * unsuccessful.
-         *
-         * @param mapperListener used to send success/failure callbacks when mapping is done.
-         */
-        public void mapNativeAd(NativeAdMapperListener mapperListener) {
-            if (!containsRequiredFieldsForNativeAppInstallAd(mNativeAd)) {
-                Log.w(TAG, "Ad from Facebook doesn't have all assets required for the app install"
-                        + " format.");
-                mapperListener.onMappingFailed();
-                return;
-            }
-
-            // Map all required assets (headline, one image, body, icon and call to
-            // action).
-            setHeadline(mNativeAd.getAdHeadline());
-            List<com.google.android.gms.ads.formats.NativeAd.Image> images = new ArrayList<>();
-            images.add(new FacebookAdapterNativeAdImage(
-                    Uri.parse(mNativeAd.getAdCoverImage().toString())));
-            setImages(images);
-            setBody(mNativeAd.getAdBodyText());
-            setIcon(new FacebookAdapterNativeAdImage(Uri.parse(mNativeAd.getAdIcon().toString())));
-            setCallToAction(mNativeAd.getAdCallToAction());
-
-            mMediaView.setListener(new MediaViewListener() {
-                @Override
-                public void onPlay(MediaView mediaView) {
-                    // Google Mobile Ads SDK doesn't have a matching event. Do nothing.
-                }
-
-                @Override
-                public void onVolumeChange(MediaView mediaView, float v) {
-                    // Google Mobile Ads SDK doesn't have a matching event. Do nothing.
-                }
-
-                @Override
-                public void onPause(MediaView mediaView) {
-                    // Google Mobile Ads SDK doesn't have a matching event. Do nothing.
-                }
-
-                @Override
-                public void onComplete(MediaView mediaView) {
-                    if (FacebookAdapter.this.mNativeListener != null) {
-                        FacebookAdapter.this.mNativeListener.onVideoEnd(FacebookAdapter.this);
-                    }
-                }
-
-                @Override
-                public void onEnterFullscreen(MediaView mediaView) {
-                    // Google Mobile Ads SDK doesn't have a matching event. Do nothing.
-                }
-
-                @Override
-                public void onExitFullscreen(MediaView mediaView) {
-                    // Google Mobile Ads SDK doesn't have a matching event. Do nothing.
-                }
-
-                @Override
-                public void onFullscreenBackground(MediaView mediaView) {
-                    // Google Mobile Ads SDK doesn't have a matching event. Do nothing.
-                }
-
-                @Override
-                public void onFullscreenForeground(MediaView mediaView) {
-                    // Google Mobile Ads SDK doesn't have a matching event. Do nothing.
-                }
-            });
-
-            // Because the FAN SDK doesn't offer a way to determine whether a native ad contains
-            // a video asset or not, the adapter always returns a MediaView and claims to have
-            // video content.
-            setMediaView(mMediaView);
-            setHasVideoContent(true);
-
-            // Map the optional assets.
-            Double starRating = getRating(mNativeAd.getAdStarRating());
-            if (starRating != null) {
-                setStarRating(starRating);
-            }
-
-            // Pass all the assets not supported by Google as extras.
-            Bundle extras = new Bundle();
-            extras.putCharSequence(KEY_ID, mNativeAd.getId());
-            extras.putCharSequence(KEY_SOCIAL_CONTEXT_ASSET, mNativeAd.getAdSocialContext());
-
-            NativeAdViewAttributes attributes = mNativeAd.getAdViewAttributes();
-            if (attributes != null) {
-                Bundle attributesBundle = new Bundle();
-                attributesBundle.putBoolean(KEY_AUTOPLAY, attributes.getAutoplay());
-                attributesBundle.putInt(KEY_BACKGROUND_COLOR, attributes.getBackgroundColor());
-                attributesBundle.putInt(KEY_BUTTON_BORDER_COLOR, attributes.getButtonBorderColor());
-                attributesBundle.putInt(KEY_BUTTON_COLOR, attributes.getButtonColor());
-                attributesBundle.putInt(KEY_BUTTON_TEXT_COLOR, attributes.getButtonTextColor());
-                attributesBundle.putInt(KEY_DESCRIPTION_TEXT_COLOR,
-                        attributes.getDescriptionTextColor());
-                attributesBundle.putInt(KEY_DESCRIPTION_TEXT_SIZE,
-                        attributes.getDescriptionTextSize());
-                attributesBundle.putInt(KEY_TITLE_TEXT_COLOR, attributes.getTitleTextColor());
-                attributesBundle.putInt(KEY_TITLE_TEXT_SIZE, attributes.getTitleTextSize());
-
-                Typeface typeface = attributes.getTypeface();
-                if (typeface != null) {
-                    Bundle typefaceBundle = new Bundle();
-                    typefaceBundle.putBoolean(KEY_IS_BOLD, typeface.isBold());
-                    typefaceBundle.putBoolean(KEY_IS_ITALIC, typeface.isItalic());
-                    typefaceBundle.putInt(KEY_STYLE, typeface.getStyle());
-                    attributesBundle.putBundle(KEY_TYPEFACE, typefaceBundle);
-                }
-                extras.putBundle(KEY_AD_VIEW_ATTRIBUTES, attributesBundle);
-            }
-            setExtras(extras);
-
-            mapperListener.onMappingSuccess();
-        }
-
-        /**
-         * This method will check whether or not the given Facebook native ad contains all the
-         * necessary fields for it to be mapped to Google Mobile Ads' native app install ad.
-         *
-         * @param nativeAd Facebook native ad.
-         * @return {@code true} if the given ad contains all the necessary fields, {@link false}
-         * otherwise.
-         */
-        private boolean containsRequiredFieldsForNativeAppInstallAd(NativeAd nativeAd) {
-            return ((nativeAd.getAdHeadline() != null) && (nativeAd.getAdCoverImage() != null)
-                    && (nativeAd.getAdBodyText() != null) && (nativeAd.getAdIcon() != null)
-                    && (nativeAd.getAdCallToAction() != null) && (mMediaView != null));
-        }
-
-        @Override
-        public void trackViews(View view,
-                               Map<String, View> clickableAssetViews,
-                               Map<String, View> nonClickableAssetViews) {
-
-            ViewGroup adView = (ViewGroup) view;
-
-            // Find the overlay view in the given ad view. The overlay view will always be the
-            // top most view in the hierarchy.
-            View overlayView = adView.getChildAt(adView.getChildCount() - 1);
-            NativeAdLayout nativeAdLayout = new NativeAdLayout(view.getContext());
-            if (overlayView instanceof FrameLayout) {
-                // Create and add Facebook's AdOptions to the overlay view.
-                AdOptionsView adOptionsView = new AdOptionsView(view.getContext(),mNativeAd,nativeAdLayout);
-                ((ViewGroup) overlayView).addView(adOptionsView);
-                // We know that the overlay view is a FrameLayout, so we get the FrameLayout's
-                // LayoutParams from the AdOptionsView.
-                FrameLayout.LayoutParams params =
-                        (FrameLayout.LayoutParams) adOptionsView.getLayoutParams();
-                if (mNativeAdOptions != null) {
-                    switch (mNativeAdOptions.getAdChoicesPlacement()) {
-                        case NativeAdOptions.ADCHOICES_TOP_LEFT:
-                            params.gravity = Gravity.TOP | Gravity.LEFT;
-                            break;
-                        case NativeAdOptions.ADCHOICES_BOTTOM_RIGHT:
-                            params.gravity = Gravity.BOTTOM | Gravity.RIGHT;
-                            break;
-                        case NativeAdOptions.ADCHOICES_BOTTOM_LEFT:
-                            params.gravity = Gravity.BOTTOM | Gravity.LEFT;
-                            break;
-                        case NativeAdOptions.ADCHOICES_TOP_RIGHT:
-                        default:
-                            params.gravity = Gravity.TOP | Gravity.RIGHT;
-                    }
-                } else {
-                    // Default to top right if native ad options are not provided.
-                    params.gravity = Gravity.TOP | Gravity.RIGHT;
-                }
-                adView.requestLayout();
-            } else {
-                AdOptionsView adOptionsView = new AdOptionsView(view.getContext(), mNativeAd, nativeAdLayout);
-                this.setAdChoicesContent(adOptionsView);
-            }
-
-            // Facebook does its own impression tracking.
-            setOverrideImpressionRecording(true);
-
-            // Facebook does its own click handling.
-            setOverrideClickHandling(true);
-            ImageView iconview = null;
-
-            ArrayList<View> assetViews = new ArrayList<>();
-            for (Map.Entry<String, View> clickableAssets : clickableAssetViews.entrySet()) {
-                assetViews.add(clickableAssets.getValue());
-
-                if (clickableAssets.getKey().equals(NativeAppInstallAd.ASSET_ICON) ||
-                        clickableAssets.getKey().equals(UnifiedNativeAdAssetNames.ASSET_ICON)) {
-                    iconview = (ImageView) clickableAssets.getValue();
-                }
-
-            }
-
-            mNativeAd.registerViewForInteraction(view, mMediaView, iconview, assetViews);
-        }
-
-
-        @Override
-        public void untrackView(View view) {
-            super.untrackView(view);
-            // Called when the native ad view no longer needs tracking. Remove any previously
-            // added trackers.
-
-            ViewGroup adView = (ViewGroup) view;
-            // Find the overlay view in the given ad view. The overlay view will always be the
-            // top most view in the hierarchy.
-            View overlayView = adView.getChildAt(adView.getChildCount() - 1);
-            if (overlayView instanceof FrameLayout) {
-                ((FrameLayout) overlayView).removeAllViews();
-            }
-
-            mNativeAd.unregisterView();
-        }
-
-        /**
-         * Convert rating to a scale of 1 to 5.
-         */
-        private Double getRating(NativeAd.Rating rating) {
-            if (rating == null) {
-                return null;
-            }
-            return (MAX_STAR_RATING * rating.getValue()) / rating.getScale();
-        }
+    protected void setDrawable(Drawable drawable) {
+      this.mDrawable = drawable;
     }
+
+    @Override
+    public Drawable getDrawable() {
+      return mDrawable;
+    }
+
+    @Override
+    public Uri getUri() {
+      return mUri;
+    }
+
+    @Override
+    public double getScale() {
+      // Default scale is 1.
+      return 1;
+    }
+  }
+
+  /**
+   * The {@link NativeAdMapperListener} interface is used to notify the success/failure
+   * events after trying to map the native ad.
+   */
+  private interface NativeAdMapperListener {
 
     /**
-     * The {@link FacebookAdapterNativeAdImage} class is a subclass of
-     * {@link com.google.android.gms.ads.formats.NativeAd.Image} used by the {@link FacebookAdapter}
-     * to create images for native ads.
+     * This method will be called once the native ad mapping is successfully.
      */
-    private class FacebookAdapterNativeAdImage extends
-            com.google.android.gms.ads.formats.NativeAd.Image {
-
-        /**
-         * A drawable for the Image.
-         */
-        private Drawable mDrawable;
-
-        /**
-         * An Uri from which the image can be obtained.
-         */
-        private Uri mUri;
-
-        /**
-         * Default constructor for {@link FacebookAdapterNativeAdImage}, requires an {@link Uri}.
-         *
-         * @param uri required to initialize.
-         */
-        public FacebookAdapterNativeAdImage(Uri uri) {
-            this.mUri = uri;
-        }
-
-        /**
-         * @param drawable set to {@link #mDrawable}.
-         */
-        protected void setDrawable(Drawable drawable) {
-            this.mDrawable = drawable;
-        }
-
-        @Override
-        public Drawable getDrawable() {
-            return mDrawable;
-        }
-
-        @Override
-        public Uri getUri() {
-            return mUri;
-        }
-
-        @Override
-        public double getScale() {
-            // Default scale is 1.
-            return 1;
-        }
-    }
+    void onMappingSuccess();
 
     /**
-     * The {@link NativeAdMapperListener} interface is used to notify the success/failure
-     * events after trying to map the native ad.
+     * This method will be called if the native ad mapping failed.
      */
-    private interface NativeAdMapperListener {
-
-        /**
-         * This method will be called once the native ad mapping is successfully.
-         */
-        void onMappingSuccess();
-
-        /**
-         * This method will be called if the native ad mapping failed.
-         */
-        void onMappingFailed();
-    }
-    //endregion
+    void onMappingFailed();
+  }
+  //endregion
 }

--- a/ThirdPartyAdapters/facebook/gradle/wrapper/gradle-wrapper.properties
+++ b/ThirdPartyAdapters/facebook/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/ThirdPartyAdapters/inmobi/CHANGELOG.md
+++ b/ThirdPartyAdapters/inmobi/CHANGELOG.md
@@ -1,5 +1,8 @@
 # InMobi Adapter for Google Mobile Ads SDK for Android Changelog
 
+## 7.2.2.0
+- Verified compatibility with InMobi SDK version 7.2.2.
+
 ## 7.2.1.0
 - Verified compatibility with InMobi SDK version 7.2.1.
 

--- a/ThirdPartyAdapters/inmobi/build.gradle
+++ b/ThirdPartyAdapters/inmobi/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/ThirdPartyAdapters/inmobi/gradle/wrapper/gradle-wrapper.properties
+++ b/ThirdPartyAdapters/inmobi/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/ThirdPartyAdapters/inmobi/inmobi/build.gradle
+++ b/ThirdPartyAdapters/inmobi/inmobi/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "7.2.1.0"
+    stringVersion = "7.2.2.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -37,7 +37,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.google.android.gms:play-services-ads:15.0.1'
-    implementation 'com.inmobi.monetization:inmobi-ads:7.2.1'
+    implementation 'com.inmobi.monetization:inmobi-ads:7.2.2'
 }
 
 /**

--- a/ThirdPartyAdapters/inmobi/inmobi/build.gradle
+++ b/ThirdPartyAdapters/inmobi/inmobi/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.google.android.gms:play-services-ads:15.0.1'
+    implementation 'com.google.android.gms:play-services-ads:17.1.1'
     implementation 'com.inmobi.monetization:inmobi-ads:7.2.2'
 }
 

--- a/ThirdPartyAdapters/inmobi/inmobi/src/main/java/com/google/ads/mediation/inmobi/InMobiAdapter.java
+++ b/ThirdPartyAdapters/inmobi/inmobi/src/main/java/com/google/ads/mediation/inmobi/InMobiAdapter.java
@@ -68,6 +68,8 @@ public final class InMobiAdapter implements MediationBannerAdapter, MediationInt
 
     private Boolean mIsOnlyUrl = false;
 
+    private InMobiNative mAdNative;
+
     /**
      * Flag to keep track of whether or not the InMobi rewarded video ad adapter has been
      * initialized.
@@ -225,7 +227,7 @@ public final class InMobiAdapter implements MediationBannerAdapter, MediationInt
 
             @Override
             public void onAdDisplayed(InMobiBanner inMobiBanner) {
-                Log.d(TAG, "onAdDismissed");
+                Log.d(TAG, "onAdDisplayed");
                 mBannerListener.onAdOpened(InMobiAdapter.this);
             }
 
@@ -561,7 +563,7 @@ public final class InMobiAdapter implements MediationBannerAdapter, MediationInt
         this.mNativeListener = listener;
 
         final Boolean serveAnyAd = (mediationAdRequest.isAppInstallAdRequested()
-                && mediationAdRequest.isContentAdRequested());
+                && mediationAdRequest.isContentAdRequested()) || mediationAdRequest.isUnifiedNativeAdRequested();;
 
        /*
         * InMobi Adapter will serve ad only if publisher requests for both AppInstall and Content
@@ -573,7 +575,7 @@ public final class InMobiAdapter implements MediationBannerAdapter, MediationInt
             return;
         }
 
-        InMobiNative adNative = new InMobiNative(context,
+        mAdNative = new InMobiNative(context,
                 Long.parseLong(serverParameters.getString("placementid")),
                 new NativeAdEventListener() {
                     @Override
@@ -653,7 +655,7 @@ public final class InMobiAdapter implements MediationBannerAdapter, MediationInt
         //Setting mediation key words to native ad object
         Set<String> mediationKeyWords = mediationAdRequest.getKeywords();
         if (null != mediationKeyWords) {
-            adNative.setKeywords(TextUtils.join(", ", mediationKeyWords));
+            mAdNative.setKeywords(TextUtils.join(", ", mediationKeyWords));
         }
 
        /*
@@ -667,11 +669,11 @@ public final class InMobiAdapter implements MediationBannerAdapter, MediationInt
 
         isTaggedForChildDirectedTreatment(mediationAdRequest, paramMap);
 
-        adNative.setExtras(paramMap);
+        mAdNative.setExtras(paramMap);
 
         InMobiAdapterUtils.buildAdRequest(mediationAdRequest, mediationExtras);
 
-        adNative.load();
+        mAdNative.load();
     }
     //endregion
 }

--- a/ThirdPartyAdapters/mopub/CHANGELOG.md
+++ b/ThirdPartyAdapters/mopub/CHANGELOG.md
@@ -1,5 +1,8 @@
 # MoPub Adapter for Google Mobile Ads SDK for Android Changelog
 
+## 5.4.1.1
+- Added support for MoPub Rewarded Video Ads.
+
 ## 5.4.1.0
 - Verified compatibility with MoPub SDK 5.4.1.
 

--- a/ThirdPartyAdapters/mopub/mopub/build.gradle
+++ b/ThirdPartyAdapters/mopub/mopub/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "5.4.1.0"
+    stringVersion = "5.4.1.1"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -21,7 +21,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 28
-        versionCode 5040100
+        versionCode 5040101
         versionName stringVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/ThirdPartyAdapters/nend/CHANGELOG.md
+++ b/ThirdPartyAdapters/nend/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Nend Adapter for Google Mobile Ads SDK for Android Changelog
 
+## 5.1.0.0
+
+- Verified compatibility with nend SDK 5.1.0.
+
 ## 5.0.2.1
 
 - Removed function that forward user features because following methods are deprecated on `AdRequest.Builder`.

--- a/ThirdPartyAdapters/nend/build.gradle
+++ b/ThirdPartyAdapters/nend/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ThirdPartyAdapters/nend/nend/build.gradle
+++ b/ThirdPartyAdapters/nend/nend/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "5.0.2.1"
+    stringVersion = "5.1.0.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -18,12 +18,12 @@ afterEvaluate {
 }
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 27
-        versionCode 5021
+        minSdkVersion 16
+        targetSdkVersion 28
+        versionCode 5100
         versionName stringVersion
     }
 
@@ -37,17 +37,15 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation('com.android.support:appcompat-v7:27.1.1') {
+    implementation('com.android.support:appcompat-v7:28.0.0') {
         exclude module: 'support-v4'
     }
-    implementation 'com.android.support:customtabs:27.1.1'
-    implementation 'com.android.support:cardview-v7:27.1.1'
-    implementation 'com.android.support:support-media-compat:27.1.1'
-    implementation 'com.android.support:support-v4:27.1.1'
-    implementation 'com.android.support:recyclerview-v7:27.1.1'
-    implementation 'com.google.android.gms:play-services-ads:15.0.1'
+    implementation 'com.android.support:customtabs:28.0.0'
+    implementation 'com.android.support:support-media-compat:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.google.android.gms:play-services-ads:17.1.2'
     // nendSDK
-    implementation 'net.nend.android:nend-sdk:5.0.2'
+    implementation 'net.nend.android:nend-sdk:5.1.0'
 }
 
 /**


### PR DESCRIPTION
Changes in Native Ads:

* NativeAdsAttributes mapping has been removed as they were not sent from the server. FAN SDK 5.2.0 has deprecated these attributes.
* Added NativeAdLayout to Native Ads views with a FrameLayout as parent.

<img width="292" alt="screen shot 2019-02-08 at 2 52 32 pm" src="https://user-images.githubusercontent.com/2929173/52511327-53b52980-2bb4-11e9-8cc8-8f4cb9dfa1c1.png">
