### PR TITLE
Updated Facebook Audience Network Adapter to version 5.2.0

### DIFF
--- a/ThirdPartyAdapters/facebook/CHANGELOG.md
+++ b/ThirdPartyAdapters/facebook/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Facebook Adapter for Google Mobile Ads SDK for Android Changelog
 
+## 5.2.0.0
+- Removed usages of NativeAdView attributes.
+- Added NativeAdLayout to Native Ads using a FrameLayout as root.
+
 ## 5.1.1.0
 - Replaced AdChoices View with AdOptions View.
 - Verified compatibility with Facebook SDK v5.1.1

--- a/ThirdPartyAdapters/facebook/facebook/build.gradle
+++ b/ThirdPartyAdapters/facebook/facebook/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "5.1.1.0"
+    stringVersion = "5.2.0.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -20,7 +20,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 26
-        versionCode 51100
+        versionCode 52000
         versionName stringVersion
     }
     buildTypes {
@@ -34,7 +34,7 @@ android {
 dependencies {
     implementation 'com.android.support:recyclerview-v7:26.1.0'
     implementation 'com.google.android.gms:play-services-ads:17.1.1'
-    implementation 'com.facebook.android:audience-network-sdk:5.1.1'
+    implementation 'com.facebook.android:audience-network-sdk:5.2.0'
 }
 
 /**

--- a/ThirdPartyAdapters/facebook/facebook/src/main/java/com/google/ads/mediation/facebook/FacebookAdapter.java
+++ b/ThirdPartyAdapters/facebook/facebook/src/main/java/com/google/ads/mediation/facebook/FacebookAdapter.java
@@ -17,7 +17,6 @@ package com.google.ads.mediation.facebook;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
-import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -47,7 +46,6 @@ import com.facebook.ads.MediaViewListener;
 import com.facebook.ads.NativeAd;
 import com.facebook.ads.NativeAdLayout;
 import com.facebook.ads.NativeAdListener;
-import com.facebook.ads.NativeAdViewAttributes;
 import com.facebook.ads.RewardedVideoAd;
 import com.facebook.ads.RewardedVideoAdListener;
 import com.google.android.gms.ads.AdRequest;
@@ -82,23 +80,8 @@ public final class FacebookAdapter
         implements MediationBannerAdapter, MediationInterstitialAdapter,
         MediationRewardedVideoAdAdapter, MediationNativeAdapter {
 
-    public static final String KEY_AD_VIEW_ATTRIBUTES = "ad_view_attributes";
-    public static final String KEY_AUTOPLAY = "autoplay";
-    public static final String KEY_BACKGROUND_COLOR = "background_color";
-    public static final String KEY_BUTTON_BORDER_COLOR = "button_border_color";
-    public static final String KEY_BUTTON_COLOR = "button_color";
-    public static final String KEY_BUTTON_TEXT_COLOR = "button_text_color";
-    public static final String KEY_DESCRIPTION_TEXT_COLOR = "description_text_color";
-    public static final String KEY_DESCRIPTION_TEXT_SIZE = "description_text_size";
     public static final String KEY_ID = "id";
-    public static final String KEY_IS_BOLD = "is_bold";
-    public static final String KEY_IS_ITALIC = "is_italic";
     public static final String KEY_SOCIAL_CONTEXT_ASSET = "social_context";
-    public static final String KEY_STYLE = "style";
-    public static final String KEY_SUBTITLE_ASSET = "subtitle";
-    public static final String KEY_TITLE_TEXT_COLOR = "title_text_color";
-    public static final String KEY_TITLE_TEXT_SIZE = "title_text_size";
-    public static final String KEY_TYPEFACE = "typeface";
 
     private static final String PLACEMENT_PARAMETER = "pubid";
 
@@ -880,32 +863,6 @@ public final class FacebookAdapter
             Bundle extras = new Bundle();
             extras.putCharSequence(KEY_ID, mNativeAd.getId());
             extras.putCharSequence(KEY_SOCIAL_CONTEXT_ASSET, mNativeAd.getAdSocialContext());
-
-            NativeAdViewAttributes attributes = mNativeAd.getAdViewAttributes();
-            if (attributes != null) {
-                Bundle attributesBundle = new Bundle();
-                attributesBundle.putBoolean(KEY_AUTOPLAY, attributes.getAutoplay());
-                attributesBundle.putInt(KEY_BACKGROUND_COLOR, attributes.getBackgroundColor());
-                attributesBundle.putInt(KEY_BUTTON_BORDER_COLOR, attributes.getButtonBorderColor());
-                attributesBundle.putInt(KEY_BUTTON_COLOR, attributes.getButtonColor());
-                attributesBundle.putInt(KEY_BUTTON_TEXT_COLOR, attributes.getButtonTextColor());
-                attributesBundle.putInt(KEY_DESCRIPTION_TEXT_COLOR,
-                        attributes.getDescriptionTextColor());
-                attributesBundle.putInt(KEY_DESCRIPTION_TEXT_SIZE,
-                        attributes.getDescriptionTextSize());
-                attributesBundle.putInt(KEY_TITLE_TEXT_COLOR, attributes.getTitleTextColor());
-                attributesBundle.putInt(KEY_TITLE_TEXT_SIZE, attributes.getTitleTextSize());
-
-                Typeface typeface = attributes.getTypeface();
-                if (typeface != null) {
-                    Bundle typefaceBundle = new Bundle();
-                    typefaceBundle.putBoolean(KEY_IS_BOLD, typeface.isBold());
-                    typefaceBundle.putBoolean(KEY_IS_ITALIC, typeface.isItalic());
-                    typefaceBundle.putInt(KEY_STYLE, typeface.getStyle());
-                    attributesBundle.putBundle(KEY_TYPEFACE, typefaceBundle);
-                }
-                extras.putBundle(KEY_AD_VIEW_ATTRIBUTES, attributesBundle);
-            }
             setExtras(extras);
 
             mapperListener.onMappingSuccess();
@@ -935,10 +892,12 @@ public final class FacebookAdapter
             // Find the overlay view in the given ad view. The overlay view will always be the
             // top most view in the hierarchy.
             View overlayView = adView.getChildAt(adView.getChildCount() - 1);
-            NativeAdLayout nativeAdLayout = new NativeAdLayout(view.getContext());
             if (overlayView instanceof FrameLayout) {
+                NativeAdLayout nativeAdLayout = new NativeAdLayout(view.getContext());
+                ((FrameLayout) overlayView).addView(nativeAdLayout);
                 // Create and add Facebook's AdOptions to the overlay view.
-                AdOptionsView adOptionsView = new AdOptionsView(view.getContext(),mNativeAd,nativeAdLayout);
+                AdOptionsView adOptionsView = new AdOptionsView(view.getContext(), mNativeAd,
+                        nativeAdLayout);
                 ((ViewGroup) overlayView).addView(adOptionsView);
                 // We know that the overlay view is a FrameLayout, so we get the FrameLayout's
                 // LayoutParams from the AdOptionsView.
@@ -965,7 +924,7 @@ public final class FacebookAdapter
                 }
                 adView.requestLayout();
             } else {
-                AdOptionsView adOptionsView = new AdOptionsView(view.getContext(), mNativeAd, nativeAdLayout);
+                AdOptionsView adOptionsView = new AdOptionsView(view.getContext(), mNativeAd, null);
                 this.setAdChoicesContent(adOptionsView);
             }
 


### PR DESCRIPTION
Preparing adapter for Facebook Audience Network 5.2.0. This adapter works with the Beta SDK which can be downloaded from https://developers.facebook.com/docs/audience-network/sdk-beta-program.

This PR includes:
*  NativeAdsAttributes mapping has been removed as they were not sent from the server. FAN SDK 5.2.0 has deprecated these attributes.
* Added NativeAdLayout to Native Ads views with a FrameLayout as parent..
* Bumping up adapter version.

<img width="292" alt="screen shot 2019-02-08 at 2 52 32 pm" src="https://user-images.githubusercontent.com/2929173/52599727-485d3a80-2e0e-11e9-8548-9474ee772e2f.png">
