### PR TITLE
Context and AppOptions Changes for AdColony Adapter

### DIFF
--- a/ThirdPartyAdapters/adcolony/adcolony/build.gradle
+++ b/ThirdPartyAdapters/adcolony/adcolony/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "3.3.8.1"
+    stringVersion = "3.3.8.2"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -21,7 +21,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 28
-        versionCode 3030801
+        versionCode 3030802
         versionName stringVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/ThirdPartyAdapters/adcolony/adcolony/src/main/java/com/jirbo/adcolony/AdColonyManager.java
+++ b/ThirdPartyAdapters/adcolony/adcolony/src/main/java/com/jirbo/adcolony/AdColonyManager.java
@@ -1,6 +1,7 @@
 package com.jirbo.adcolony;
 
 import android.app.Activity;
+import android.app.Application;
 import android.content.Context;
 import android.location.Location;
 import android.os.Bundle;
@@ -48,8 +49,8 @@ public class AdColonyManager {
 
         boolean needToConfigure = false;
 
-        if (!(context instanceof Activity)) {
-            Log.w(TAG, "Context must be of type Activity.");
+        if (!(context instanceof Activity || context instanceof Application)) {
+            Log.w(TAG, "Context must be of type Activity or Application.");
             return false;
         }
 
@@ -76,14 +77,17 @@ public class AdColonyManager {
         AdColonyAppOptions appOptions = buildAppOptions(adRequest, networkExtras);
         AdColony.setAppOptions(appOptions);
 
-        // We are requesting zones that we haven't configured with yet.
-        if (!isConfigured && needToConfigure) {
-            // Convert configuredZones into array.
+        if (isConfigured && !needToConfigure) {
+            AdColony.setAppOptions(appOptions);
+        } else {
+            // We are requesting zones that we haven't configured with yet.
             String[] zones = configuredZones.toArray(new String[0]);
 
             // Always set mediation network info.
             appOptions.setMediationNetwork(AdColonyAppOptions.ADMOB, BuildConfig.VERSION_NAME);
-            isConfigured = AdColony.configure((Activity) context, appOptions, appId, zones);
+            isConfigured = context instanceof Activity
+                    ? AdColony.configure((Activity) context, appOptions, appId, zones)
+                    : AdColony.configure((Application) context, appOptions, appId, zones);
         }
         return isConfigured;
     }
@@ -97,8 +101,8 @@ public class AdColonyManager {
 
         boolean needToConfigure = false;
 
-        if (!(context instanceof Activity)) {
-            Log.w(TAG, "Context must be of type Activity.");
+        if (!(context instanceof Activity || context instanceof Application)) {
+            Log.w(TAG, "Context must be of type Activity or Application.");
             return false;
         }
 
@@ -123,16 +127,17 @@ public class AdColonyManager {
 
         // Update app-options if necessary.
         AdColonyAppOptions appOptions = buildAppOptions(adConfiguration);
-        AdColony.setAppOptions(appOptions);
-
-        // We are requesting zones that we haven't configured with yet.
-        if (!isConfigured && needToConfigure) {
-            // Convert configuredZones into array.
+        if (isConfigured && !needToConfigure) {
+            AdColony.setAppOptions(appOptions);
+        } else {
+            // We are requesting zones that we haven't configured with yet.
             String[] zones = configuredZones.toArray(new String[0]);
 
             // Always set mediation network info.
             appOptions.setMediationNetwork(AdColonyAppOptions.ADMOB, BuildConfig.VERSION_NAME);
-            isConfigured = AdColony.configure((Activity) context, appOptions, appId, zones);
+            isConfigured = context instanceof Activity
+                    ? AdColony.configure((Activity) context, appOptions, appId, zones)
+                    : AdColony.configure((Application) context, appOptions, appId, zones);
         }
         return isConfigured;
     }

--- a/ThirdPartyAdapters/adcolony/adcolony/src/main/java/com/jirbo/adcolony/AdColonyManager.java
+++ b/ThirdPartyAdapters/adcolony/adcolony/src/main/java/com/jirbo/adcolony/AdColonyManager.java
@@ -47,8 +47,6 @@ public class AdColonyManager {
         String appId = serverParams.getString(AdColonyAdapterUtils.KEY_APP_ID);
         ArrayList<String> newZoneList = parseZoneList(serverParams);
 
-        boolean needToConfigure = false;
-
         if (!(context instanceof Activity || context instanceof Application)) {
             Log.w(TAG, "Context must be of type Activity or Application.");
             return false;
@@ -69,15 +67,14 @@ public class AdColonyManager {
             if (!configuredZones.contains(zone)) {
                 // Not contained in our list.
                 configuredZones.add(zone);
-                needToConfigure = true;
+                isConfigured = false;
             }
         }
 
         // Update app-options if necessary.
         AdColonyAppOptions appOptions = buildAppOptions(adRequest, networkExtras);
-        AdColony.setAppOptions(appOptions);
 
-        if (isConfigured && !needToConfigure) {
+        if (isConfigured) {
             AdColony.setAppOptions(appOptions);
         } else {
             // We are requesting zones that we haven't configured with yet.
@@ -99,8 +96,6 @@ public class AdColonyManager {
         String appId = serverParams.getString(AdColonyAdapterUtils.KEY_APP_ID);
         ArrayList<String> newZoneList = parseZoneList(serverParams);
 
-        boolean needToConfigure = false;
-
         if (!(context instanceof Activity || context instanceof Application)) {
             Log.w(TAG, "Context must be of type Activity or Application.");
             return false;
@@ -121,13 +116,14 @@ public class AdColonyManager {
             if (!configuredZones.contains(zone)) {
                 // Not contained in our list.
                 configuredZones.add(zone);
-                needToConfigure = true;
+                isConfigured = false;
             }
         }
 
         // Update app-options if necessary.
         AdColonyAppOptions appOptions = buildAppOptions(adConfiguration);
-        if (isConfigured && !needToConfigure) {
+
+        if (isConfigured) {
             AdColony.setAppOptions(appOptions);
         } else {
             // We are requesting zones that we haven't configured with yet.


### PR DESCRIPTION
AdColony v3.3.6 added support for Application in addition to Activity in configure(), so I've altered both the instanceof checks and the calls to configure() to be aware of this.

Additionally, there were changes made to the setAppOptions() and configure() logic [in this commit](https://github.com/googleads/googleads-mobile-android-mediation/commit/a79ea4730a7cf1d418d3eaf6e61f022df787fa2a#diff-ef1d9c56d259f438a1f3eff6ca4b2091R77) (look around line 77 in AdColonyManager.java).

The problem with this is twofold, both of which I have made changes around:

1. The AdColony API is not available until after configure(), so setAppOptions() is designed in a way to be used only if AppOptions has changed at runtime, post-configuration - otherwise the object can just be passed into the configure() call. If the publisher has not manually configured AdColony, this will lead to an ignored call to setAppOptions() that will additionally fire a warning log the first time we are passed an ad request.
2. Removing the else and instead flipping the isConfigured and needToConfigure flags doesn't work, as configure() will no longer be called if AdColony is configured but the set of zones have changed (i.e. if both isConfigured and needToConfigure is true).