### PR TITLE
Fixed Facebook banner mapping using 320x50

### DIFF
--- a/ThirdPartyAdapters/facebook/facebook/src/main/java/com/google/ads/mediation/facebook/FacebookAdapter.java
+++ b/ThirdPartyAdapters/facebook/facebook/src/main/java/com/google/ads/mediation/facebook/FacebookAdapter.java
@@ -538,11 +538,6 @@ public final class FacebookAdapter extends FacebookMediationAdapter
         }
         Log.i(TAG, "Found closest ad size: " + closestSize.toString());
 
-        if (closestSize.getWidth() == com.facebook.ads.AdSize.BANNER_320_50.getWidth()
-                && closestSize.getHeight() == com.facebook.ads.AdSize.BANNER_320_50.getHeight()) {
-            return com.facebook.ads.AdSize.BANNER_320_50;
-        }
-
         int adHeight = closestSize.getHeight();
         if (adHeight == com.facebook.ads.AdSize.BANNER_HEIGHT_50.getHeight()) {
             return com.facebook.ads.AdSize.BANNER_HEIGHT_50;


### PR DESCRIPTION
FacebookAdapter uses a deprecated size 320x50 and FAN not is not filling requests mapped to this size. Banner unit's width is flexible and the view will use the provided space.