### PR TITLE
Remove references to placement in AppLovin adapter

### DIFF
--- a/ThirdPartyAdapters/applovin/applovin/src/main/java/com/applovin/mediation/AppLovinUtils.java
+++ b/ThirdPartyAdapters/applovin/applovin/src/main/java/com/applovin/mediation/AppLovinUtils.java
@@ -27,7 +27,6 @@ public class AppLovinUtils {
    */
   private static class ServerParameterKeys {
     private static final String SDK_KEY = "sdkKey";
-    private static final String PLACEMENT = "placement";
     private static final String ZONE_ID = "zone_id";
   }
 
@@ -77,18 +76,6 @@ public class AppLovinUtils {
     }
 
     return null;
-  }
-
-  /**
-   * Retrieves the placement from an appropriate connector object. Will use empty string if none
-   * exists.
-   */
-  public static String retrievePlacement(Bundle serverParameters) {
-    if (serverParameters.containsKey(ServerParameterKeys.PLACEMENT)) {
-      return serverParameters.getString(ServerParameterKeys.PLACEMENT);
-    } else {
-      return null;
-    }
   }
 
   /**

--- a/ThirdPartyAdapters/applovin/applovin/src/main/java/com/applovin/mediation/ApplovinAdapter.java
+++ b/ThirdPartyAdapters/applovin/applovin/src/main/java/com/applovin/mediation/ApplovinAdapter.java
@@ -60,7 +60,6 @@ public class ApplovinAdapter extends AppLovinMediationAdapter
     private AppLovinAdView mAdView;
 
     // Controlled fields.
-    private String mPlacement;
     private String mZoneId;
 
     //region MediationInterstitialAdapter implementation.
@@ -76,18 +75,16 @@ public class ApplovinAdapter extends AppLovinMediationAdapter
         mNetworkExtras = networkExtras;
         mMediationInterstitialListener = interstitialListener;
 
-        mPlacement = AppLovinUtils.retrievePlacement(serverParameters);
         mZoneId = AppLovinUtils.retrieveZoneId(serverParameters);
 
-        log(DEBUG, "Requesting interstitial for zone: " + mZoneId + " and placement: "
-                + mPlacement);
+        log(DEBUG, "Requesting interstitial for zone: " + mZoneId);
 
         // Create Ad Load listener.
         final AppLovinAdLoadListener adLoadListener = new AppLovinAdLoadListener() {
             @Override
             public void adReceived(final AppLovinAd ad) {
                 log(DEBUG, "Interstitial did load ad: " + ad.getAdIdNumber() + " for zone: "
-                        + mZoneId + " and placement: " + mPlacement);
+                        + mZoneId);
 
                 synchronized (INTERSTITIAL_AD_QUEUES_LOCK) {
                     Queue<AppLovinAd> preloadedAds = INTERSTITIAL_AD_QUEUES.get(mZoneId);
@@ -163,16 +160,15 @@ public class ApplovinAdapter extends AppLovinMediationAdapter
             interstitialAd.setAdVideoPlaybackListener(listener);
 
             if (dequeuedAd != null) {
-                log(DEBUG, "Showing interstitial for zone: " + mZoneId + " placement: "
-                        + mPlacement);
-                interstitialAd.showAndRender(dequeuedAd, mPlacement);
+                log(DEBUG, "Showing interstitial for zone: " + mZoneId);
+                interstitialAd.showAndRender(dequeuedAd);
             } else {
                 log(DEBUG, "Attempting to show interstitial before one was loaded");
 
                 // Check if we have a default zone interstitial available.
                 if (TextUtils.isEmpty(mZoneId) && interstitialAd.isAdReadyToDisplay()) {
                     log(DEBUG, "Showing interstitial preloaded by SDK");
-                    interstitialAd.show(mPlacement);
+                    interstitialAd.show();
                 }
                 // TODO: Show ad for zone identifier if exists
                 else {
@@ -195,11 +191,10 @@ public class ApplovinAdapter extends AppLovinMediationAdapter
         // Store parent objects
         mSdk = AppLovinUtils.retrieveSdk(serverParameters, context);
 
-        mPlacement = AppLovinUtils.retrievePlacement(serverParameters);
         mZoneId = AppLovinUtils.retrieveZoneId(serverParameters);
 
         log(DEBUG, "Requesting banner of size " + adSize + " for zone: "
-                + mZoneId + " and placement: " + mPlacement);
+                + mZoneId);
 
         // Convert requested size to AppLovin Ad Size.
         final AppLovinAdSize appLovinAdSize = AppLovinUtils.appLovinAdSizeFromAdMobAdSize(context, adSize);

--- a/ThirdPartyAdapters/applovin/applovin/src/main/java/com/google/ads/mediation/applovin/AppLovinMediationAdapter.java
+++ b/ThirdPartyAdapters/applovin/applovin/src/main/java/com/google/ads/mediation/applovin/AppLovinMediationAdapter.java
@@ -61,7 +61,6 @@ public class AppLovinMediationAdapter extends RtbAdapter
     // Rewarded Video objects.
     private MediationRewardedAdCallback mRewardedAdCallback;
     private AppLovinIncentivizedInterstitial mIncentivizedInterstitial;
-    private String mPlacement;
     private String mZoneId;
     private Bundle mNetworkExtras;
     private MediationRewardedAdConfiguration adConfiguration;
@@ -127,14 +126,12 @@ public class AppLovinMediationAdapter extends RtbAdapter
         if (!isRtbAd) {
             synchronized (INCENTIVIZED_ADS_LOCK) {
                 Bundle serverParameters = adConfiguration.getServerParameters();
-                mPlacement = AppLovinUtils.retrievePlacement(serverParameters);
                 mZoneId = AppLovinUtils.retrieveZoneId(serverParameters);
                 mSdk = AppLovinUtils.retrieveSdk(serverParameters, adConfiguration.getContext());
                 mNetworkExtras = adConfiguration.getMediationExtras();
                 mMediationAdLoadCallback = mediationAdLoadCallback;
 
-                String logMessage = String.format("Requesting rewarded video for zone '%s' " +
-                        "and placement '%s'.", mZoneId, mPlacement);
+                String logMessage = String.format("Requesting rewarded video for zone '%s'", mZoneId);
                 log(DEBUG, logMessage);
 
                 // Check if incentivized ad for zone already exists.
@@ -176,8 +173,7 @@ public class AppLovinMediationAdapter extends RtbAdapter
     @Override
     public void showAd(Context context) {
         mSdk.getSettings().setMuted(AppLovinUtils.shouldMuteAudio(mNetworkExtras));
-        String logMessage = String.format("Showing rewarded video for zone '%s', placement '%s'",
-                mZoneId, mPlacement);
+        String logMessage = String.format("Showing rewarded video for zone '%s'", mZoneId);
         log(DEBUG, logMessage);
         final AppLovinIncentivizedAdListener listener =
                 new AppLovinIncentivizedAdListener(adConfiguration, mRewardedAdCallback);


### PR DESCRIPTION
AppLovin deprecated placements and the usages are already removed, but these logs and such still remain.