### PR TITLE
Add smart banner support to i-mobile adapter

### DIFF
--- a/ThirdPartyAdapters/imobile/CHANGELOG.md
+++ b/ThirdPartyAdapters/imobile/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## i-mobile Android Mediation Adapter Changelog
 
+#### Version 2.0.20.2
+- Added support for Smart Banner (50 dp height).
+
 #### Version 2.0.20.1
 - Adapter now returns a non-zero `mediaContent` aspect ratio.
 

--- a/ThirdPartyAdapters/imobile/imobile/build.gradle
+++ b/ThirdPartyAdapters/imobile/imobile/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "2.0.20.1"
+    stringVersion = "2.0.20.2"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -19,7 +19,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 28
-        versionCode 2002001
+        versionCode 2002002
         versionName stringVersion
     }
     buildTypes {


### PR DESCRIPTION
Display i-mobile 320x50 banner if the height of the smart banner is 50dp and the width is greater than or equal to 320dp.