### PR TITLE
Chartboost adapters 8.0.1.0

### DIFF
--- a/ThirdPartyAdapters/chartboost/chartboost/build.gradle
+++ b/ThirdPartyAdapters/chartboost/chartboost/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "com.jfrog.bintray" version "1.8.4"
 }
+
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 
@@ -9,7 +10,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "7.5.0.1"
+    stringVersion = "8.0.1.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -17,7 +18,7 @@ ext {
 android {
     compileSdkVersion 28
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 7050001
         versionName stringVersion
@@ -28,14 +29,17 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
-    // Adding Chartboost SDK as a compileOnly dependency makes sure that the jar is not included in the
-    // AAR.
-    compileOnly files('libs/chartboost.jar')
+    implementation 'com.chartboost:chartboost-sdk:8.0.1'
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.gms:play-services-ads:18.3.0'
+    implementation 'com.google.android.gms:play-services-ads:19.0.0'
     implementation 'com.google.android.gms:play-services-base:17.1.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:17.0.0'
 }

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostBannerErrorListener.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostBannerErrorListener.java
@@ -1,0 +1,9 @@
+package com.google.ads.mediation.chartboost;
+
+/**
+ * The {@link ChartboostBannerErrorListener} custom interface to notify
+ * {@link ChartboostAdapter} that banner init caused an error
+ */
+public interface ChartboostBannerErrorListener {
+    void notifyBannerInitializationError(int error);
+}

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostMediationAdapter.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostMediationAdapter.java
@@ -82,12 +82,6 @@ public class ChartboostMediationAdapter extends Adapter implements MediationRewa
     public void initialize(Context context,
                            InitializationCompleteCallback initializationCompleteCallback,
                            List<MediationConfiguration> mediationConfigurations) {
-        if (!(context instanceof Activity)) {
-            initializationCompleteCallback.onInitializationFailed(
-                    "Chartboost SDK requires an Activity context to initialize");
-            return;
-        }
-
         HashMap<String, Bundle> chartboostConfigs = new HashMap<>();
         for (MediationConfiguration configuration : mediationConfigurations) {
             Bundle params = configuration.getServerParameters();
@@ -126,7 +120,7 @@ public class ChartboostMediationAdapter extends Adapter implements MediationRewa
                     "Initialization Failed: Invalid server parameters.");
             return;
         }
-
+        
         ChartboostSingleton.startChartboostRewardedVideo(
                 context, mChartboostRewardedVideoDelegate);
     }

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostParams.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostParams.java
@@ -14,6 +14,7 @@
 
 package com.google.ads.mediation.chartboost;
 
+import com.chartboost.sdk.Banner.BannerSize;
 import com.chartboost.sdk.CBLocation;
 import com.chartboost.sdk.Chartboost.CBFramework;
 
@@ -49,6 +50,10 @@ public class ChartboostParams {
      */
     private String cbFrameworkVersion;
 
+    /**
+     * Size of the Chartboost banner required to create a banner
+     */
+    private BannerSize cbBannerSize;
     /**
      * Default constructor, sets a default value for {@link #cbLocation}.
      */
@@ -124,5 +129,19 @@ public class ChartboostParams {
      */
     public void setFrameworkVersion(String version) {
         this.cbFrameworkVersion = version;
+    }
+
+    /**
+     * @return {@link #cbBannerSize}.
+     */
+    public BannerSize getBannerSize() {
+        return cbBannerSize;
+    }
+
+    /**
+     * @param bannerSize {@link #cbBannerSize}.
+     */
+    public void setBannerSize(BannerSize bannerSize) {
+        this.cbBannerSize = bannerSize;
     }
 }


### PR DESCRIPTION
Changes:

1. Update Chartboost mediation adapter to work with latest Chartboost SDK version 8.0.1
 - support banners
 - remove activity dependency and activity lifecycle
2. Implement custom banner adapter