### PR TITLE
Release Vungle 6.7.0 adapter

### DIFF
--- a/ThirdPartyAdapters/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/build.gradle
@@ -15,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        maven { url 'https://jitpack.io' }
         google()
         jcenter()
     }

--- a/ThirdPartyAdapters/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/build.gradle
@@ -15,7 +15,6 @@ buildscript {
 
 allprojects {
     repositories {
-        maven { url 'https://jitpack.io' }
         google()
         jcenter()
     }

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "6.6.0.0"
+    stringVersion = "6.7.0.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -23,7 +23,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 28
-        versionCode 6060000
+        versionCode 6070000
         versionName stringVersion
     }
     buildTypes {
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-    implementation ('com.vungle:publisher-sdk-android:6.5.3') {
+    implementation ('com.github.vungle:vungle-android-sdk:6.7.0') {
         transitive=true
     }
 

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-    implementation ('com.github.vungle:vungle-android-sdk:6.7.0') {
+    implementation ('com.vungle:publisher-sdk-android:6.7.0') {
         transitive=true
     }
 

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "6.5.3.0"
+    stringVersion = "6.6.0.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -23,7 +23,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 28
-        versionCode 6050300
+        versionCode 6060000
         versionName stringVersion
     }
     buildTypes {

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
@@ -267,29 +267,54 @@ public class VungleMediationAdapter extends Adapter
   }
 
   @Override
+  @Deprecated
   public void onAdEnd(
       final String placementID,
       final boolean wasSuccessfulView,
       final boolean wasCallToActionClicked) {
-    mHandler.post(
-        new Runnable() {
-          @Override
-          public void run() {
-            if (mMediationRewardedAdCallback != null) {
-              if (wasSuccessfulView) {
-                mMediationRewardedAdCallback.onVideoComplete();
-                mMediationRewardedAdCallback.onUserEarnedReward(new VungleReward("vungle", 1));
-              }
-              if (wasCallToActionClicked) {
-                // Only the call to action button is clickable for Vungle ads. So the
-                // wasCallToActionClicked can be used for tracking clicks.
-                mMediationRewardedAdCallback.reportAdClicked();
-              }
-              mMediationRewardedAdCallback.onAdClosed();
-            }
-            mPlacementsInUse.remove(placementID);
-          }
-        });
+  }
+
+  @Override
+  public void onAdEnd(final String placementID) {
+    mHandler.post(new Runnable() {
+      @Override
+      public void run() {
+        if (mMediationRewardedAdCallback != null) {
+          mMediationRewardedAdCallback.onAdClosed();
+        }
+        mPlacementsInUse.remove(placementID);
+      }
+    });
+  }
+
+  @Override
+  public void onAdClick(String placementID) {
+    mHandler.post(new Runnable() {
+      @Override
+      public void run() {
+        if (mMediationRewardedAdCallback != null) {
+          mMediationRewardedAdCallback.reportAdClicked();
+        }
+      }
+    });
+  }
+
+  @Override
+  public void onAdRewarded(String placementID) {
+    mHandler.post(new Runnable() {
+      @Override
+      public void run() {
+        if (mMediationRewardedAdCallback != null) {
+          mMediationRewardedAdCallback.onVideoComplete();
+          mMediationRewardedAdCallback.onUserEarnedReward(new VungleReward("vungle", 1));
+        }
+      }
+    });
+  }
+
+  @Override
+  public void onAdLeftApplication(String placementID) {
+    //no op
   }
 
   // Vungle's LoadAdCallback and PlayAdCallback shares the same onError() call; when an

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
@@ -124,6 +124,10 @@ class VungleBannerAdapter {
     }
   }
 
+  /**
+   * This method is a workaround for banner leak issue, and most callers should
+   * use {@link VungleBannerAdapter#destroy(View)}.
+   */
   void destroy() {
     destroy(mAdLayout.get());
   }

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
@@ -203,7 +203,6 @@ class VungleBannerAdapter {
           VungleListener listener = getVungleListener();
           if (mPendingRequestBanner && listener != null) {
             listener.onAdEnd(placementId);
-            listener.onAdClosed(placementId);
           }
         }
 

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
@@ -194,10 +194,39 @@ class VungleBannerAdapter {
         }
 
         @Override
+        @Deprecated
         public void onAdEnd(String placementId, boolean completed, boolean isCTAClicked) {
+        }
+
+        @Override
+        public void onAdEnd(String placementId) {
           VungleListener listener = getVungleListener();
           if (mPendingRequestBanner && listener != null) {
-            listener.onAdEnd(placementId, completed, isCTAClicked);
+            listener.onAdEnd(placementId);
+          }
+        }
+
+        @Override
+        public void onAdClick(String placementId) {
+          VungleListener listener = getVungleListener();
+          if (mPendingRequestBanner && listener != null) {
+            listener.onAdClick(placementId);
+          }
+        }
+
+        @Override
+        public void onAdRewarded(String placementId) {
+          VungleListener listener = getVungleListener();
+          if (mPendingRequestBanner && listener != null) {
+            listener.onAdRewarded(placementId);
+          }
+        }
+
+        @Override
+        public void onAdLeftApplication(String placementId) {
+          VungleListener listener = getVungleListener();
+          if (mPendingRequestBanner && listener != null) {
+            listener.onAdLeftApplication(placementId);
           }
         }
 

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
@@ -203,6 +203,7 @@ class VungleBannerAdapter {
           VungleListener listener = getVungleListener();
           if (mPendingRequestBanner && listener != null) {
             listener.onAdEnd(placementId);
+            listener.onAdClosed(placementId);
           }
         }
 

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
@@ -17,6 +17,7 @@ import com.vungle.warren.Vungle;
 import com.vungle.warren.VungleBanner;
 import com.vungle.warren.VungleNativeAd;
 import com.vungle.warren.error.VungleException;
+import java.lang.ref.WeakReference;
 
 class VungleBannerAdapter {
 
@@ -29,10 +30,10 @@ class VungleBannerAdapter {
   @Nullable private String mUniquePubRequestId;
 
   /** Vungle listener class to forward to the adapter. */
-  @Nullable private VungleListener mVungleListener;
+  @NonNull private WeakReference<VungleListener> mVungleListener = new WeakReference<>(null);
 
   /** Container for Vungle's banner ad view. */
-  @NonNull private RelativeLayout mAdLayout;
+  @NonNull private WeakReference<RelativeLayout> mAdLayout = new WeakReference<>(null);
 
   /** Vungle ad configuration settings. */
   @NonNull private AdConfig mAdConfig;
@@ -67,12 +68,24 @@ class VungleBannerAdapter {
     return mUniquePubRequestId;
   }
 
+  //Use weak references to allow VungleInterstitialAdapter to be garbage collected.
+  //Banner view need to be added/removed on adLayout's onAttachedToWindow/onDetachedFromWindow
+  //to break view's parent-child references chain to the leaked VungleBannerAdapter in VungleManager.
   void setAdLayout(@NonNull RelativeLayout adLayout) {
-    this.mAdLayout = adLayout;
+    this.mAdLayout = new WeakReference<>(adLayout);
   }
 
   void setVungleListener(@Nullable VungleListener vungleListener) {
-    this.mVungleListener = vungleListener;
+    this.mVungleListener = new WeakReference<>(vungleListener);
+  }
+
+  @Nullable
+  private VungleListener getVungleListener() {
+    return mVungleListener.get();
+  }
+
+  boolean hasAdapter() {
+    return mAdLayout.get() != null;
   }
 
   void requestBannerAd(@NonNull Context context, @NonNull String appId) {
@@ -91,9 +104,10 @@ class VungleBannerAdapter {
               @Override
               public void onInitializeError(String errorMessage) {
                 Log.d(TAG, "SDK init failed: " + VungleBannerAdapter.this);
+                VungleListener listener = getVungleListener();
                 mVungleManager.removeActiveBannerAd(mPlacementId);
-                if (mPendingRequestBanner && mVungleListener != null) {
-                  mVungleListener.onAdFailedToLoad(AdRequest.ERROR_CODE_INTERNAL_ERROR);
+                if (mPendingRequestBanner && listener != null) {
+                  listener.onAdFailedToLoad(AdRequest.ERROR_CODE_INTERNAL_ERROR);
                 }
               }
             });
@@ -101,13 +115,17 @@ class VungleBannerAdapter {
 
   void destroy(@Nullable View adView) {
     Log.d(TAG, "Vungle banner adapter try to destroy:" + this);
-    if (adView == mAdLayout) {
+    if (adView == mAdLayout.get()) {
       Log.d(TAG, "Vungle banner adapter destroy:" + this);
       mVisibility = false;
-      mPendingRequestBanner = false;
       mVungleManager.removeActiveBannerAd(mPlacementId);
       cleanUp();
+      mPendingRequestBanner = false;
     }
+  }
+
+  void destroy() {
+    destroy(mAdLayout.get());
   }
 
   void cleanUp() {
@@ -116,9 +134,7 @@ class VungleBannerAdapter {
     if (mVungleBannerAd != null) {
       Log.d(TAG, "Vungle banner adapter cleanUp: destroyAd # " + mVungleBannerAd.hashCode());
       mVungleBannerAd.destroyAd();
-      if (mVungleBannerAd != null && mVungleBannerAd.getParent() != null) {
-        ((ViewGroup) mVungleBannerAd.getParent()).removeView(mVungleBannerAd);
-      }
+      detach();
       mVungleBannerAd = null;
     }
 
@@ -126,12 +142,7 @@ class VungleBannerAdapter {
       Log.d(
           TAG, "Vungle banner adapter cleanUp: finishDisplayingAd # " + mVungleNativeAd.hashCode());
       mVungleNativeAd.finishDisplayingAd();
-      if (mVungleNativeAd != null) {
-        View adView = mVungleNativeAd.renderNativeView();
-        if (adView != null && adView.getParent() != null) {
-          ((ViewGroup) adView.getParent()).removeView(adView);
-        }
-      }
+      detach();
       mVungleNativeAd = null;
     }
   }
@@ -164,9 +175,10 @@ class VungleBannerAdapter {
         @Override
         public void onError(String id, VungleException exception) {
           Log.d(TAG, "Ad load failed:" + VungleBannerAdapter.this);
+          VungleListener listener = getVungleListener();
           mVungleManager.removeActiveBannerAd(mPlacementId);
-          if (mPendingRequestBanner && mVungleListener != null) {
-            mVungleListener.onAdFailedToLoad(AdRequest.ERROR_CODE_NO_FILL);
+          if (mPendingRequestBanner && listener != null) {
+            listener.onAdFailedToLoad(AdRequest.ERROR_CODE_NO_FILL);
           }
         }
       };
@@ -175,24 +187,27 @@ class VungleBannerAdapter {
       new PlayAdCallback() {
         @Override
         public void onAdStart(String placementId) {
-          if (mPendingRequestBanner && mVungleListener != null) {
-            mVungleListener.onAdStart(placementId);
+          VungleListener listener = getVungleListener();
+          if (mPendingRequestBanner && listener != null) {
+            listener.onAdStart(placementId);
           }
         }
 
         @Override
         public void onAdEnd(String placementId, boolean completed, boolean isCTAClicked) {
-          if (mPendingRequestBanner && mVungleListener != null) {
-            mVungleListener.onAdEnd(placementId, completed, isCTAClicked);
+          VungleListener listener = getVungleListener();
+          if (mPendingRequestBanner && listener != null) {
+            listener.onAdEnd(placementId, completed, isCTAClicked);
           }
         }
 
         @Override
         public void onError(String placementId, VungleException exception) {
           Log.d(TAG, "Ad play failed:" + VungleBannerAdapter.this);
+          VungleListener listener = getVungleListener();
           mVungleManager.removeActiveBannerAd(mPlacementId);
-          if (mPendingRequestBanner && mVungleListener != null) {
-            mVungleListener.onAdFail(placementId);
+          if (mPendingRequestBanner && listener != null) {
+            listener.onAdFail(placementId);
           }
         }
       };
@@ -218,6 +233,7 @@ class VungleBannerAdapter {
             RelativeLayout.LayoutParams.WRAP_CONTENT, RelativeLayout.LayoutParams.WRAP_CONTENT);
     adParams.addRule(RelativeLayout.CENTER_HORIZONTAL, RelativeLayout.TRUE);
     adParams.addRule(RelativeLayout.CENTER_VERTICAL, RelativeLayout.TRUE);
+    VungleListener listener = getVungleListener();
 
     if (AdConfig.AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
       mVungleBannerAd = Banners.getBanner(mPlacementId, mAdConfig.getAdSize(), mAdPlayCallback);
@@ -226,14 +242,14 @@ class VungleBannerAdapter {
         mVungleManager.storeActiveBannerAd(mPlacementId, this);
         updateVisibility(mVisibility);
         mVungleBannerAd.setLayoutParams(adParams);
-        mAdLayout.addView(mVungleBannerAd);
-        if (mVungleListener != null) {
-          mVungleListener.onAdAvailable();
+        // don't add to parent here
+        if (listener != null) {
+          listener.onAdAvailable();
         }
       } else {
         // missing resources
-        if (mVungleListener != null) {
-          mVungleListener.onAdFailedToLoad(AdRequest.ERROR_CODE_INTERNAL_ERROR);
+        if (listener != null) {
+          listener.onAdFailedToLoad(AdRequest.ERROR_CODE_INTERNAL_ERROR);
         }
       }
     } else {
@@ -247,14 +263,14 @@ class VungleBannerAdapter {
         Log.d(TAG, "display MREC:" + mVungleNativeAd.hashCode() + this);
         updateVisibility(mVisibility);
         adView.setLayoutParams(adParams);
-        mAdLayout.addView(adView);
-        if (mVungleListener != null) {
-          mVungleListener.onAdAvailable();
+        // don't add to parent here
+        if (listener != null) {
+          listener.onAdAvailable();
         }
       } else {
         // missing resources
-        if (mVungleListener != null) {
-          mVungleListener.onAdFailedToLoad(AdRequest.ERROR_CODE_INTERNAL_ERROR);
+        if (listener != null) {
+          listener.onAdFailedToLoad(AdRequest.ERROR_CODE_INTERNAL_ERROR);
         }
       }
     }
@@ -271,4 +287,32 @@ class VungleBannerAdapter {
         + hashCode()
         + "] ";
   }
+
+  void attach() {
+    RelativeLayout layout = mAdLayout.get();
+    if (layout != null) {
+      if (mVungleBannerAd != null && mVungleBannerAd.getParent() == null) {
+        layout.addView(mVungleBannerAd);
+      }
+      if (mVungleNativeAd != null) {
+        View adView = mVungleNativeAd.renderNativeView();
+        if (adView != null && adView.getParent() == null) {
+          layout.addView(adView);
+        }
+      }
+    }
+  }
+
+  void detach() {
+    if (mVungleBannerAd != null && mVungleBannerAd.getParent() != null) {
+      ((ViewGroup) mVungleBannerAd.getParent()).removeView(mVungleBannerAd);
+    }
+    if (mVungleNativeAd != null) {
+      View adView = mVungleNativeAd.renderNativeView();
+      if (adView != null && adView.getParent() != null) {
+        ((ViewGroup) adView.getParent()).removeView(adView);
+      }
+    }
+  }
+
 }

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleExtrasBuilder.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleExtrasBuilder.java
@@ -77,13 +77,18 @@ public final class VungleExtrasBuilder {
 
   public static AdConfig adConfigWithNetworkExtras(Bundle networkExtras) {
     AdConfig adConfig = new AdConfig();
-    adConfig.setMuted(true); // start muted by default.
+    adConfig.setMuted(false); // Unmute fullscreen ads by default
     if (networkExtras != null) {
-      adConfig.setMuted(networkExtras.getBoolean(EXTRA_START_MUTED, true));
+      adConfig.setMuted(networkExtras.getBoolean(EXTRA_START_MUTED, false));
       adConfig.setFlexViewCloseTime(networkExtras.getInt(EXTRA_FLEXVIEW_CLOSE_TIME, 0));
       adConfig.setOrdinal(networkExtras.getInt(EXTRA_ORDINAL_VIEW_COUNT, 0));
       adConfig.setAdOrientation(networkExtras.getInt(EXTRA_ORIENTATION, AdConfig.AUTO_ROTATE));
     }
     return adConfig;
   }
+
+  static boolean isStartMutedNotConfigured(Bundle networkExtras) {
+    return networkExtras == null || !networkExtras.containsKey(EXTRA_START_MUTED);
+  }
+
 }

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -14,18 +14,13 @@
 
 package com.vungle.mediation;
 
-import static com.vungle.warren.AdConfig.AdSize.BANNER;
-import static com.vungle.warren.AdConfig.AdSize.BANNER_LEADERBOARD;
-import static com.vungle.warren.AdConfig.AdSize.BANNER_SHORT;
-import static com.vungle.warren.AdConfig.AdSize.VUNGLE_MREC;
-
 import android.content.Context;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 import android.widget.RelativeLayout;
-import androidx.annotation.Keep;
+
 import com.google.ads.mediation.vungle.VungleInitializer;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdSize;
@@ -36,7 +31,15 @@ import com.google.android.gms.ads.mediation.MediationBannerListener;
 import com.google.android.gms.ads.mediation.MediationInterstitialAdapter;
 import com.google.android.gms.ads.mediation.MediationInterstitialListener;
 import com.vungle.warren.AdConfig;
+
 import java.util.ArrayList;
+
+import androidx.annotation.Keep;
+
+import static com.vungle.warren.AdConfig.AdSize.BANNER;
+import static com.vungle.warren.AdConfig.AdSize.BANNER_LEADERBOARD;
+import static com.vungle.warren.AdConfig.AdSize.BANNER_SHORT;
+import static com.vungle.warren.AdConfig.AdSize.VUNGLE_MREC;
 
 /**
  * A {@link MediationInterstitialAdapter} used to load and show Vungle interstitial ads using Google
@@ -258,7 +261,7 @@ public class VungleInterstitialAdapter
 
     AdConfig adConfig = VungleExtrasBuilder.adConfigWithNetworkExtras(mediationExtras);
     if (VungleExtrasBuilder.isStartMutedNotConfigured(mediationExtras)) {
-      mAdConfig.setMuted(true); // start muted by default
+      adConfig.setMuted(true); // start muted by default
     }
     if (!hasBannerSizeAd(context, adSize, adConfig)) {
       String message = "Failed to load ad from Vungle: Invalid banner size.";

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -330,20 +330,15 @@ public class VungleInterstitialAdapter
 
         @Override
         void onAdEnd(String placementId) {
-          //no op
+            if (mMediationBannerListener != null) {
+                mMediationBannerListener.onAdClosed(VungleInterstitialAdapter.this);
+            }
         }
 
         @Override
         void onAdLeftApplication(String placementId) {
           if (mMediationBannerListener != null) {
             mMediationBannerListener.onAdLeftApplication(VungleInterstitialAdapter.this);
-          }
-        }
-
-        @Override
-        void onAdClosed(String placementId) {
-          if (mMediationBannerListener != null) {
-            mMediationBannerListener.onAdClosed(VungleInterstitialAdapter.this);
           }
         }
 

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -257,6 +257,9 @@ public class VungleInterstitialAdapter
     }
 
     AdConfig adConfig = VungleExtrasBuilder.adConfigWithNetworkExtras(mediationExtras);
+    if (VungleExtrasBuilder.isStartMutedNotConfigured(mediationExtras)) {
+      mAdConfig.setMuted(true); // start muted by default
+    }
     if (!hasBannerSizeAd(context, adSize, adConfig)) {
       String message = "Failed to load ad from Vungle: Invalid banner size.";
       Log.w(TAG, message);

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -259,7 +259,24 @@ public class VungleInterstitialAdapter
 
     // Create the adLayout wrapper with the requested ad size, as Vungle's ad uses MATCH_PARENT for
     // its dimensions.
-    adLayout = new RelativeLayout(context);
+    adLayout = new RelativeLayout(context) {
+      @Override
+      protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        if (mBannerRequest != null) {
+          mBannerRequest.attach();
+        }
+      }
+
+      @Override
+      protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        if (mBannerRequest != null) {
+          mBannerRequest.detach();
+        }
+      }
+    };
+
     int adLayoutHeight = adSize.getHeightInPixels(context);
     // If the height is 0 (e.g. for inline adaptive banner requests), use the closest supported size
     // as the height of the adLayout wrapper.

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -151,15 +151,23 @@ public class VungleInterstitialAdapter
           mAdConfig,
           new VungleListener() {
             @Override
-            void onAdEnd(
-                String placement, boolean wasSuccessfulView, boolean wasCallToActionClicked) {
+            void onAdClick(String placementId) {
               if (mMediationInterstitialListener != null) {
-                if (wasCallToActionClicked) {
-                  // Only the call to action button is clickable for Vungle ads. So the
-                  // wasCallToActionClicked can be used for tracking clicks.
-                  mMediationInterstitialListener.onAdClicked(VungleInterstitialAdapter.this);
-                }
+                mMediationInterstitialListener.onAdClicked(VungleInterstitialAdapter.this);
+              }
+            }
+
+            @Override
+            void onAdEnd(String placementId) {
+              if (mMediationInterstitialListener != null) {
                 mMediationInterstitialListener.onAdClosed(VungleInterstitialAdapter.this);
+              }
+            }
+
+            @Override
+            void onAdLeftApplication(String placementId) {
+              if (mMediationInterstitialListener != null) {
+                mMediationInterstitialListener.onAdLeftApplication(VungleInterstitialAdapter.this);
               }
             }
 
@@ -276,7 +284,6 @@ public class VungleInterstitialAdapter
         }
       }
     };
-
     int adLayoutHeight = adSize.getHeightInPixels(context);
     // If the height is 0 (e.g. for inline adaptive banner requests), use the closest supported size
     // as the height of the adLayout wrapper.
@@ -308,15 +315,29 @@ public class VungleInterstitialAdapter
   private VungleListener mVungleBannerListener =
       new VungleListener() {
         @Override
-        void onAdEnd(String placement, boolean wasSuccessfulView, boolean wasCallToActionClicked) {
+        void onAdClick(String placementId) {
           if (mMediationBannerListener != null) {
-            if (wasCallToActionClicked) {
-              // Only the call to action button is clickable for Vungle ads. So the
-              // wasCallToActionClicked can be used for tracking clicks.
-              mMediationBannerListener.onAdClicked(VungleInterstitialAdapter.this);
-              mMediationBannerListener.onAdOpened(VungleInterstitialAdapter.this);
-              mMediationBannerListener.onAdClosed(VungleInterstitialAdapter.this);
-            }
+            mMediationBannerListener.onAdClicked(VungleInterstitialAdapter.this);
+            mMediationBannerListener.onAdOpened(VungleInterstitialAdapter.this);
+          }
+        }
+
+        @Override
+        void onAdEnd(String placementId) {
+          //no op
+        }
+
+        @Override
+        void onAdLeftApplication(String placementId) {
+          if (mMediationBannerListener != null) {
+            mMediationBannerListener.onAdLeftApplication(VungleInterstitialAdapter.this);
+          }
+        }
+
+        @Override
+        void onAdClosed(String placementId) {
+          if (mMediationBannerListener != null) {
+            mMediationBannerListener.onAdClosed(VungleInterstitialAdapter.this);
           }
         }
 

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleListener.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleListener.java
@@ -14,8 +14,6 @@ abstract class VungleListener {
 
   void onAdLeftApplication(String placementId) {}
 
-  void onAdClosed(String placementId) {}
-
   void onAdStart(String placement) {}
 
   void onAdFail(String placement) {}

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleListener.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleListener.java
@@ -6,7 +6,15 @@ package com.vungle.mediation;
  */
 abstract class VungleListener {
 
-  void onAdEnd(String placement, boolean wasSuccessfulView, boolean wasCallToActionClicked) {}
+  void onAdClick(String placementId) {}
+
+  void onAdEnd(String placementId) {}
+
+  void onAdRewarded(String placementId) {}
+
+  void onAdLeftApplication(String placementId) {}
+
+  void onAdClosed(String placementId) {}
 
   void onAdStart(String placement) {}
 

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
@@ -92,9 +92,35 @@ public class VungleManager {
       }
 
       @Override
+      @Deprecated
       public void onAdEnd(String id, boolean completed, boolean isCTAClicked) {
+      }
+
+      @Override
+      public void onAdEnd(String id) {
         if (listener != null) {
-          listener.onAdEnd(id, completed, isCTAClicked);
+          listener.onAdEnd(id);
+        }
+      }
+
+      @Override
+      public void onAdClick(String id) {
+        if (listener != null) {
+          listener.onAdClick(id);
+        }
+      }
+
+      @Override
+      public void onAdRewarded(String id) {
+        if (listener != null) {
+          listener.onAdRewarded(id);
+        }
+      }
+
+      @Override
+      public void onAdLeftApplication(String id) {
+        if (listener != null) {
+          listener.onAdLeftApplication(id);
         }
       }
 


### PR DESCRIPTION
1. Verified compatibility with Vungle SDK 6.7.0.
2. Fetch and merge AdMob latest master source code.
3. Ad playback callback changes: support adClick, adLeftApplication, etc.
4. Workaround banner leak when AdMob destroy method not invoked correctly.
5. Fix bugs: unmute fullscreen ads by default except for banner/MREC.
