### PR TITLE
Banner refactored patch

### DIFF
--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -14,29 +14,21 @@
 
 package com.vungle.mediation;
 
-import static com.vungle.warren.AdConfig.AdSize.BANNER;
-import static com.vungle.warren.AdConfig.AdSize.BANNER_LEADERBOARD;
-import static com.vungle.warren.AdConfig.AdSize.BANNER_SHORT;
-import static com.vungle.warren.AdConfig.AdSize.VUNGLE_MREC;
-
 import android.content.Context;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
-import android.widget.RelativeLayout;
 import androidx.annotation.Keep;
 import com.google.ads.mediation.vungle.VungleInitializer;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdSize;
-import com.google.android.gms.ads.MediationUtils;
 import com.google.android.gms.ads.mediation.MediationAdRequest;
 import com.google.android.gms.ads.mediation.MediationBannerAdapter;
 import com.google.android.gms.ads.mediation.MediationBannerListener;
 import com.google.android.gms.ads.mediation.MediationInterstitialAdapter;
 import com.google.android.gms.ads.mediation.MediationInterstitialListener;
 import com.vungle.warren.AdConfig;
-import java.util.ArrayList;
 
 /**
  * A {@link MediationInterstitialAdapter} used to load and show Vungle interstitial ads using Google
@@ -52,18 +44,12 @@ public class VungleInterstitialAdapter
   private AdConfig mAdConfig;
   private String mPlacementForPlay;
 
-  // banner/MREC
-  private volatile RelativeLayout adLayout;
-  private MediationBannerListener mMediationBannerListener;
-  private VungleBannerAdapter mBannerRequest;
+  private VungleBannerAdapter vungleBannerAdapter;
 
   @Override
-  public void requestInterstitialAd(
-      Context context,
-      MediationInterstitialListener mediationInterstitialListener,
-      Bundle serverParameters,
-      MediationAdRequest mediationAdRequest,
-      Bundle mediationExtras) {
+  public void requestInterstitialAd(Context context,
+      MediationInterstitialListener mediationInterstitialListener, Bundle serverParameters,
+      MediationAdRequest mediationAdRequest, Bundle mediationExtras) {
 
     AdapterParametersParser.Config config;
     try {
@@ -192,217 +178,43 @@ public class VungleInterstitialAdapter
   @Override
   public void onDestroy() {
     Log.d(TAG, "onDestroy: " + hashCode());
-    if (mBannerRequest != null) {
-      mBannerRequest.destroy(adLayout);
-      mBannerRequest = null;
+    if (vungleBannerAdapter != null) {
+      vungleBannerAdapter.onDestroy();
     }
-    adLayout = null;
   }
 
-  // banner
   @Override
   public void onPause() {
     Log.d(TAG, "onPause");
-    if (mBannerRequest != null) {
-      mBannerRequest.updateVisibility(false);
+    if (vungleBannerAdapter != null) {
+      vungleBannerAdapter.onPause();
     }
   }
 
   @Override
   public void onResume() {
     Log.d(TAG, "onResume");
-    if (mBannerRequest != null) {
-      mBannerRequest.updateVisibility(true);
+    if (vungleBannerAdapter != null) {
+      vungleBannerAdapter.onResume();
     }
   }
 
   @Override
-  public void requestBannerAd(
-      Context context,
-      final MediationBannerListener mediationBannerListener,
-      Bundle serverParameters,
-      AdSize adSize,
-      MediationAdRequest mediationAdRequest,
+  public void requestBannerAd(Context context, MediationBannerListener mediationBannerListener,
+      Bundle serverParameters, AdSize adSize, MediationAdRequest mediationAdRequest,
       Bundle mediationExtras) {
-    Log.d(TAG, "requestBannerAd");
-    mMediationBannerListener = mediationBannerListener;
-
-    AdapterParametersParser.Config config;
-    try {
-      config = AdapterParametersParser.parse(mediationExtras, serverParameters);
-    } catch (IllegalArgumentException e) {
-      Log.w(TAG, "Failed to load ad from Vungle.", e);
-      if (mediationBannerListener != null) {
-        mediationBannerListener.onAdFailedToLoad(
-            VungleInterstitialAdapter.this, AdRequest.ERROR_CODE_INVALID_REQUEST);
-      }
-      return;
-    }
-
-    mVungleManager = VungleManager.getInstance();
-
-    String placementForPlay = mVungleManager.findPlacement(mediationExtras, serverParameters);
-    Log.d(
-        TAG,
-        "requestBannerAd for Placement: "
-            + placementForPlay
-            + " ###  Adapter instance: "
-            + this.hashCode());
-
-    if (TextUtils.isEmpty(placementForPlay)) {
-      String message = "Failed to load ad from Vungle: Missing or Invalid Placement ID.";
-      Log.w(TAG, message);
-      mMediationBannerListener.onAdFailedToLoad(
-          VungleInterstitialAdapter.this, AdRequest.ERROR_CODE_INVALID_REQUEST);
-      return;
-    }
-
-    AdConfig adConfig = VungleExtrasBuilder.adConfigWithNetworkExtras(mediationExtras, true);
-    if (!hasBannerSizeAd(context, adSize, adConfig)) {
-      String message = "Failed to load ad from Vungle: Invalid banner size.";
-      Log.w(TAG, message);
-      mMediationBannerListener.onAdFailedToLoad(
-          VungleInterstitialAdapter.this, AdRequest.ERROR_CODE_INVALID_REQUEST);
-      return;
-    }
-
-    // Create the adLayout wrapper with the requested ad size, as Vungle's ad uses MATCH_PARENT for
-    // its dimensions.
-    adLayout =
-        new RelativeLayout(context) {
-          @Override
-          protected void onAttachedToWindow() {
-            super.onAttachedToWindow();
-            if (mBannerRequest != null) {
-              mBannerRequest.attach();
-            }
-          }
-
-          @Override
-          protected void onDetachedFromWindow() {
-            super.onDetachedFromWindow();
-            if (mBannerRequest != null) {
-              mBannerRequest.detach();
-            }
-          }
-        };
-    int adLayoutHeight = adSize.getHeightInPixels(context);
-    // If the height is 0 (e.g. for inline adaptive banner requests), use the closest supported size
-    // as the height of the adLayout wrapper.
-    if (adLayoutHeight <= 0) {
-      float density = context.getResources().getDisplayMetrics().density;
-      adLayoutHeight = Math.round(adConfig.getAdSize().getHeight() * density);
-    }
-    RelativeLayout.LayoutParams adViewLayoutParams =
-        new RelativeLayout.LayoutParams(adSize.getWidthInPixels(context), adLayoutHeight);
-    adLayout.setLayoutParams(adViewLayoutParams);
-
-    mBannerRequest =
-        mVungleManager.getBannerRequest(placementForPlay, config.getRequestUniqueId(), adConfig);
-    if (mBannerRequest == null) {
-      // Adapter does not support multiple Banner instances playing for same placement except for
-      // Refresh
-      mMediationBannerListener.onAdFailedToLoad(
-          VungleInterstitialAdapter.this, AdRequest.ERROR_CODE_INVALID_REQUEST);
-      return;
-    }
-
-    mBannerRequest.setAdLayout(adLayout);
-    mBannerRequest.setVungleListener(mVungleBannerListener);
-
-    Log.d(TAG, "Requesting banner with ad size: " + adConfig.getAdSize());
-    mBannerRequest.requestBannerAd(context, config.getAppId());
+    vungleBannerAdapter = new VungleBannerAdapter(context, VungleInterstitialAdapter.this,
+        mediationBannerListener);
+    vungleBannerAdapter
+        .requestBannerAd(adSize, mediationAdRequest, serverParameters, mediationExtras);
   }
-
-  private VungleListener mVungleBannerListener =
-      new VungleListener() {
-        @Override
-        void onAdClick(String placementId) {
-          if (mMediationBannerListener != null) {
-            mMediationBannerListener.onAdClicked(VungleInterstitialAdapter.this);
-            mMediationBannerListener.onAdOpened(VungleInterstitialAdapter.this);
-          }
-        }
-
-        @Override
-        void onAdEnd(String placementId) {
-          if (mMediationBannerListener != null) {
-            mMediationBannerListener.onAdClosed(VungleInterstitialAdapter.this);
-          }
-        }
-
-        @Override
-        void onAdLeftApplication(String placementId) {
-          if (mMediationBannerListener != null) {
-            mMediationBannerListener.onAdLeftApplication(VungleInterstitialAdapter.this);
-          }
-        }
-
-        @Override
-        void onAdAvailable() {
-          if (mMediationBannerListener != null) {
-            mMediationBannerListener.onAdLoaded(VungleInterstitialAdapter.this);
-          }
-        }
-
-        @Override
-        void onAdStart(String placement) {
-          // let's load it again to mimic auto-cache, don't care about errors
-          if (mBannerRequest != null) {
-            mBannerRequest.preCache();
-          }
-        }
-
-        @Override
-        void onAdFail(String placement) {
-          Log.w(TAG, "Ad playback error Placement: " + placement + ";" + mBannerRequest);
-        }
-
-        @Override
-        void onAdFailedToLoad(int errorCode) {
-          Log.w(TAG, "Failed to load ad from Vungle: " + errorCode + ";" + mBannerRequest);
-          if (mMediationBannerListener != null) {
-            mMediationBannerListener.onAdFailedToLoad(VungleInterstitialAdapter.this, errorCode);
-          }
-        }
-      };
 
   @Override
   public View getBannerView() {
-    Log.d(TAG, "getBannerView # instance: " + hashCode());
-    return adLayout;
+    if (vungleBannerAdapter != null) {
+      return vungleBannerAdapter.getBannerView();
+    }
+    return null;
   }
 
-  private boolean hasBannerSizeAd(Context context, AdSize adSize, AdConfig adConfig) {
-    ArrayList<AdSize> potentials = new ArrayList<>();
-    potentials.add(new AdSize(BANNER_SHORT.getWidth(), BANNER_SHORT.getHeight()));
-    potentials.add(new AdSize(BANNER.getWidth(), BANNER.getHeight()));
-    potentials.add(new AdSize(BANNER_LEADERBOARD.getWidth(), BANNER_LEADERBOARD.getHeight()));
-    potentials.add(new AdSize(VUNGLE_MREC.getWidth(), VUNGLE_MREC.getHeight()));
-
-    AdSize closestSize = MediationUtils.findClosestSize(context, adSize, potentials);
-    if (closestSize == null) {
-      Log.i(TAG, "Not found closest ad size: " + adSize);
-      return false;
-    }
-    Log.i(
-        TAG,
-        "Found closest ad size: " + closestSize.toString() + " for requested ad size: " + adSize);
-
-    if (closestSize.getWidth() == BANNER_SHORT.getWidth()
-        && closestSize.getHeight() == BANNER_SHORT.getHeight()) {
-      adConfig.setAdSize(BANNER_SHORT);
-    } else if (closestSize.getWidth() == BANNER.getWidth()
-        && closestSize.getHeight() == BANNER.getHeight()) {
-      adConfig.setAdSize(BANNER);
-    } else if (closestSize.getWidth() == BANNER_LEADERBOARD.getWidth()
-        && closestSize.getHeight() == BANNER_LEADERBOARD.getHeight()) {
-      adConfig.setAdSize(BANNER_LEADERBOARD);
-    } else if (closestSize.getWidth() == VUNGLE_MREC.getWidth()
-        && closestSize.getHeight() == VUNGLE_MREC.getHeight()) {
-      adConfig.setAdSize(VUNGLE_MREC);
-    }
-
-    return true;
-  }
 }

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -44,6 +44,10 @@ public class VungleInterstitialAdapter
   private AdConfig mAdConfig;
   private String mPlacementForPlay;
 
+  /**
+   * Ad container for Vungle's banner ad.
+   */
+  private volatile View adLayout;
   private VungleBannerAdapter vungleBannerAdapter;
 
   @Override
@@ -180,6 +184,8 @@ public class VungleInterstitialAdapter
     Log.d(TAG, "onDestroy: " + hashCode());
     if (vungleBannerAdapter != null) {
       vungleBannerAdapter.onDestroy();
+      vungleBannerAdapter = null;
+      adLayout = null;
     }
   }
 
@@ -205,16 +211,13 @@ public class VungleInterstitialAdapter
       Bundle mediationExtras) {
     vungleBannerAdapter = new VungleBannerAdapter(context, VungleInterstitialAdapter.this,
         mediationBannerListener);
-    vungleBannerAdapter
+    adLayout = vungleBannerAdapter
         .requestBannerAd(adSize, mediationAdRequest, serverParameters, mediationExtras);
   }
 
   @Override
   public View getBannerView() {
-    if (vungleBannerAdapter != null) {
-      return vungleBannerAdapter.getBannerView();
-    }
-    return null;
+    return adLayout;
   }
 
 }

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
@@ -207,10 +207,37 @@ public class VungleManager {
     }
   }
 
-  void storeActiveBannerAd(@NonNull String placementId, @NonNull VungleBannerAdapter instance) {
-    if (!mVungleBanners.containsKey(placementId)) {
+  /**
+   * maintain banner adapter instance, replace banner adapter instance if banner view changed.
+   *
+   * @param placementId placement
+   * @param instance    banner adapter instance with updated banner or MREC
+   * @param updated     banner instance updated after cleanUp
+   */
+  void storeActiveBannerAd(@NonNull String placementId, @NonNull VungleBannerAdapter instance,
+      boolean updated) {
+    if (!mVungleBanners.containsKey(placementId) || updated) {
       mVungleBanners.put(placementId, instance);
       Log.d(TAG, "restoreActiveBannerAd:" + instance + "; size=" + mVungleBanners.size());
+    }
+  }
+
+  /**
+   * cleanup active banner and MREC instance
+   *
+   * @param placementId placement
+   */
+  void cleanUpActiveBannerAd(@NonNull String placementId) {
+    VungleBannerAdapter activeBannerAd = mVungleBanners.get(placementId);
+    if (activeBannerAd != null) {
+      activeBannerAd.cleanUp();
+    }
+  }
+
+  void destroyBannerAd(@NonNull VungleBannerAdapter bannerAdapter) {
+    VungleBannerAdapter activeBannerAd = mVungleBanners.get(bannerAdapter.getPlacementId());
+    if (activeBannerAd == bannerAdapter) {
+      activeBannerAd.destroy();
     }
   }
 }


### PR DESCRIPTION
This patch PR is helpful to fix the refactoring PR proposed from AdMob: https://github.com/googleads/googleads-mobile-android-mediation/pull/271

1. Vungle banner instance must be finished before the subsequent display.
2. VungleInterstitialAdapter#onDestroy is not invoked in time. So we must ensure the current showing banner not be destroyed by the previous onDestroy() call.
3. banner adapter leak. VungleInterstitialAdapter#onDestroy sometimes not invoked, so we need to have an opportunity to clear leaked banner instance.