### PR TITLE
Vungle update to version 6.7.1

### DIFF
--- a/ThirdPartyAdapters/vungle/CHANGELOG.md
+++ b/ThirdPartyAdapters/vungle/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Vungle Android Mediation Adapter Changelog
 
+#### Version 6.7.1.0
+- Verified compatibility with Vungle SDK 6.7.1.
+- Various Bug Fixes
+- Adapter has been tested only for up to API version 29.
+- Vungle 6.7.1 SDK has support for Android 11, and has resolved some issues in order to be used with API version 30
+
 #### Version 6.7.0.0
 - Verified compatibility with Vungle SDK 6.7.0.
 - Updated the adapter to support inline adaptive banner requests.

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -10,20 +10,20 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "6.7.0.0"
+    stringVersion = "6.7.1.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     lintOptions {
         abortOnError false
     }
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 6070000
+        versionCode 6070100
         versionName stringVersion
     }
     buildTypes {
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-    implementation ('com.vungle:publisher-sdk-android:6.7.0') {
+    implementation ('com.vungle:publisher-sdk-android:6.7.1') {
         transitive=true
     }
 

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
@@ -150,6 +150,8 @@ public class VungleMediationAdapter extends Adapter
           mediationAdLoadCallback) {
     mMediationAdLoadCallback = mediationAdLoadCallback;
 
+    Context context = mediationRewardedAdConfiguration.getContext();
+
     Bundle mediationExtras = mediationRewardedAdConfiguration.getMediationExtras();
     Bundle serverParameters = mediationRewardedAdConfiguration.getServerParameters();
 


### PR DESCRIPTION
Updating Vungle from 6.7.0 to 6.7.1
Adding back in line removed from:
https://github.com/googleads/googleads-mobile-android-mediation/commit/28738e9f2b9fc446f1f95587a2135e7504c5b1a0#diff-c1f0849a50e777b58a3b95dffff4041cL159