### PR TITLE
Set Rewarded Listener when AdColony is not initialized

### DIFF
--- a/ThirdPartyAdapters/adcolony/adcolony/src/main/java/com/google/ads/mediation/adcolony/AdColonyRewardedEventForwarder.java
+++ b/ThirdPartyAdapters/adcolony/adcolony/src/main/java/com/google/ads/mediation/adcolony/AdColonyRewardedEventForwarder.java
@@ -21,12 +21,18 @@ class AdColonyRewardedEventForwarder extends AdColonyInterstitialListener
     if (instance == null) {
       instance = new AdColonyRewardedEventForwarder();
     }
+    setRewardedListener();
     return instance;
+  }
+
+  private static void setRewardedListener() {
+    if (AdColony.getRewardListener() == null) {
+      AdColony.setRewardListener(instance);
+    }
   }
 
   private AdColonyRewardedEventForwarder() {
     mListeners = new HashMap<>();
-    AdColony.setRewardListener(AdColonyRewardedEventForwarder.this);
   }
 
   void addListener(@NonNull String zoneID, @NonNull AdColonyRewardedRenderer listener) {


### PR DESCRIPTION
Rewarded listener was not correctly configured when AdColony Network was not early initialized. This caused that the Rewarded callback is not called when the video reward is completed. #243 