### PR TITLE
Vungle 6.7.1 - Adding back missing context reference

### DIFF
--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
@@ -187,7 +187,7 @@ public class VungleMediationAdapter extends Adapter
     VungleInitializer.getInstance()
         .initialize(
             appID,
-            context.getApplicationContext(),
+                mediationRewardedAdConfiguration.getContext().getApplicationContext(),
             new VungleInitializationListener() {
               @Override
               public void onInitializeSuccess() {


### PR DESCRIPTION
Adding back necessary context for rewarded ads