### PR TITLE
Upgrading to Vungle 6.8.1

### DIFF
--- a/ThirdPartyAdapters/vungle/CHANGELOG.md
+++ b/ThirdPartyAdapters/vungle/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Vungle Android Mediation Adapter Changelog
 
+#### Version 6.8.1.0
+- Verified compatibility with Vungle SDK 6.8.1.
+
+Built and tested with:
+- Google Mobile Ads SDK version 19.4.0.
+- Vungle SDK version 6.8.1.
+
 #### Version 6.8.0.0
 - Verified compatibility with Vungle SDK 6.8.0.
 - Updated the adapter to not forward `onAdClosed()` when banner ads are refreshed or destroyed.

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "6.8.0.0"
+    stringVersion = "6.8.1.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -23,7 +23,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 6080000
+        versionCode 6080100
         versionName stringVersion
     }
     buildTypes {
@@ -36,7 +36,7 @@ android {
 
 dependencies {
 
-    implementation ('com.vungle:publisher-sdk-android:6.8.0') {
+    implementation ('com.vungle:publisher-sdk-android:6.8.1') {
         transitive=true
     }
 

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
@@ -335,6 +335,11 @@ public class VungleMediationAdapter extends Adapter
         });
   }
 
+  @Override
+  public void onAdViewed(String id) {
+    // "no-op , to be mapped to respective adapter events in future release"
+  }
+
   /**
    * This class is used to map Vungle rewarded video ad rewards to Google Mobile Ads SDK rewards.
    */

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleBannerAdapter.java
@@ -243,6 +243,11 @@ class VungleBannerAdapter {
             listener.onAdFail(placementId);
           }
         }
+
+        @Override
+        public void onAdViewed(String id) {
+          // "no-op , to be mapped to respective adapter events in future release"
+        }
       };
 
   private void loadBanner() {

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleManager.java
@@ -129,6 +129,11 @@ public class VungleManager {
           listener.onAdFail(id);
         }
       }
+
+      @Override
+      public void onAdViewed(String id) {
+        // "no-op , to be mapped to respective adapter events in future release"
+      }
     };
   }
 


### PR DESCRIPTION
Updating Vungle Admob Adapter to support Vungle 6.8.1

Currently onAdViewed is not mapped to any mediation callbacks so there are no changes in adapter callback behavior compared to the previous release.