### PR TITLE
fix: move setDelegate to avoid missing Chartboost network initialization callback

### DIFF
--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostSingleton.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostSingleton.java
@@ -263,13 +263,13 @@ public final class ChartboostSingleton {
     }
 
     mIsChartboostInitializing = true;
+    Chartboost.setDelegate(getInstance());
     Chartboost.startWithAppId(context, params.getAppId(), params.getAppSignature());
     Chartboost.setMediation(
         Chartboost.CBMediation.CBMediationAdMob,
         Chartboost.getSDKVersion(),
         com.google.ads.mediation.chartboost.BuildConfig.VERSION_NAME);
     Chartboost.setLoggingLevel(CBLogging.Level.INTEGRATION);
-    Chartboost.setDelegate(getInstance());
     Chartboost.setAutoCacheAds(false);
   }
 


### PR DESCRIPTION
You could miss the callback if you set the delegate after the network initialization.