### PR TITLE
Vungle Adapter Update to 6.10.2

### DIFF
--- a/ThirdPartyAdapters/vungle/CHANGELOG.md
+++ b/ThirdPartyAdapters/vungle/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Vungle Android Mediation Adapter Changelog
 
+#### Version 6.10.2.0
+ - Fix adapter issue with passing of the Unique ID to help with concurrent Banner request for same Banner AdUnit. This was broken since re-work around error handling
+ - Fix for low occurring ConcurrentModificationException crash in Vungle’s SDK
+
 #### Version 6.10.1.0
 - Verified compatibility with Vungle SDK 6.10.1.
 - Updated the minimum required Google Mobile Ads SDK version to 20.3.0.

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -8,7 +8,7 @@ ext {
     // String property to store the proper name of the mediation network adapter.
     adapterName = "Vungle"
     // String property to store version name.
-    stringVersion = "6.10.1.0"
+    stringVersion = "6.10.2.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30
-        versionCode 6100100
+        versionCode 6100200
         versionName stringVersion
         buildConfigField("String", "ADAPTER_VERSION", "\"${stringVersion}\"")
     }
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    implementation ('com.vungle:publisher-sdk-android:6.10.1') {
+    implementation ('com.vungle:publisher-sdk-android:6.10.2') {
         transitive=true
     }
 

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -82,7 +82,7 @@ public class VungleInterstitialAdapter
       return;
     }
 
-    AdapterParametersParser.Config config = AdapterParametersParser.parse(appID, serverParameters);
+    AdapterParametersParser.Config config = AdapterParametersParser.parse(appID, mediationExtras);
     // Unmute full-screen ads by default.
     mAdConfig = VungleExtrasBuilder.adConfigWithNetworkExtras(mediationExtras, false);
     VungleInitializer.getInstance()
@@ -242,7 +242,7 @@ public class VungleInterstitialAdapter
     mMediationBannerListener = mediationBannerListener;
     String appID = serverParameters.getString(KEY_APP_ID);
     AdapterParametersParser.Config config;
-    config = AdapterParametersParser.parse(appID, serverParameters);
+    config = AdapterParametersParser.parse(appID, mediationExtras);
 
     if (TextUtils.isEmpty(appID)) {
 


### PR DESCRIPTION
**Update to Latest Vungle 6.10.2**

Adapter rebuilt with Vungle's SDK V6.10.2

**Change Log:**
- Fix adapter issue with passing of the Unique ID to help  with concurrent Banner request for same Banner AdUnit. 
This was broken since re-work around error handling

- Fix for low occurring ConcurrentModificationException crash in Vungle’s SDK

