### PR TITLE
Updating Vungle to 6.10.3

### DIFF
--- a/ThirdPartyAdapters/vungle/CHANGELOG.md
+++ b/ThirdPartyAdapters/vungle/CHANGELOG.md
@@ -1,8 +1,15 @@
 ## Vungle Android Mediation Adapter Changelog
 
+#### Version 6.10.3.0
+- Verified compatibility with Vungle SDK 6.10.3.
+
+Built and tested with:
+- Google Mobile Ads SDK version 20.5.0.
+- Vungle SDK version 6.10.3.
+
 #### Version 6.10.2.1
 - Verified compatibility with Vungle SDK 6.10.2.
-- Added bidding support for banner, interstitial and rewarded ad formats.
+- Added bidding support for interstitial and rewarded ad formats.
 - Updated the minimum required Google Mobile Ads SDK version to 20.5.0.
 
 Built and tested with:
@@ -10,8 +17,8 @@ Built and tested with:
 - Vungle SDK version 6.10.2.
 
 #### Version 6.10.2.0
- - Verified compatibility with Vungle SDK 6.10.2.
- - Fixed an adapter issue by replacing parameter `serverParameters`, with `mediationExtras` to obtain Vungle network-specific parameters, when requesting Banner and Interstitial ads.
+- Verified compatibility with Vungle SDK 6.10.2.
+- Fixed an adapter issue by replacing parameter `serverParameters`, with `mediationExtras` to obtain Vungle network-specific parameters, when requesting Banner and Interstitial ads.
 
 Built and tested with:
 - Google Mobile Ads SDK version 20.3.0.
@@ -135,10 +142,10 @@ Built and tested with:
 - Verified compatibility with Vungle SDK 5.3.2.
 - Updated the Adpater project for Android Studio 3.0.
 - Added the following methods to Bundle builder class.
-   - `setOrdinalViewCount` : This field is used to pass the mediation ordinal,
-   whenever Publisher receives the ordinal data reports from Vungle.
-   - `setFlexViewCloseTimeInSec` : This option is used to make flex view ads
-   dismiss on their own after the specified number of seconds.
+    - `setOrdinalViewCount` : This field is used to pass the mediation ordinal,
+      whenever Publisher receives the ordinal data reports from Vungle.
+    - `setFlexViewCloseTimeInSec` : This option is used to make flex view ads
+      dismiss on their own after the specified number of seconds.
 
 #### Version 5.3.0.0
 - Verified compatibility with Vungle SDK 5.3.0.

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -8,7 +8,7 @@ ext {
     // String property to store the proper name of the mediation network adapter.
     adapterName = "Vungle"
     // String property to store version name.
-    stringVersion = "6.10.2.1"
+    stringVersion = "6.10.3.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30
-        versionCode 6100201
+        versionCode 6100300
         versionName stringVersion
         buildConfigField("String", "ADAPTER_VERSION", "\"${stringVersion}\"")
     }
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    implementation ('com.vungle:publisher-sdk-android:6.10.2') {
+    implementation ('com.vungle:publisher-sdk-android:6.10.3') {
         transitive=true
     }
 

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleInitializer.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleInitializer.java
@@ -5,6 +5,8 @@ import android.os.Handler;
 import android.os.Looper;
 import androidx.annotation.NonNull;
 import com.google.android.gms.ads.AdError;
+import com.google.android.gms.ads.MobileAds;
+import com.google.android.gms.ads.RequestConfiguration;
 import com.vungle.mediation.VungleConsent;
 import com.vungle.mediation.VungleNetworkSettings;
 import com.vungle.warren.InitCallback;
@@ -59,9 +61,12 @@ public class VungleInitializer implements InitCallback {
             }
 
             // Pass new settings to SDK.
+            updateCoppaStatus(MobileAds.getRequestConfiguration().getTagForChildDirectedTreatment());
             Vungle.init(appId, context.getApplicationContext(), VungleInitializer.this, settings);
           }
         });
+
+    updateCoppaStatus(MobileAds.getRequestConfiguration().getTagForChildDirectedTreatment());
 
     VungleSettings vungleSettings = VungleNetworkSettings.getVungleSettings();
     Vungle.init(appId, context.getApplicationContext(), VungleInitializer.this, vungleSettings);
@@ -107,6 +112,21 @@ public class VungleInitializer implements InitCallback {
   @Override
   public void onAutoCacheAdAvailable(String placementId) {
     // Unused
+  }
+
+  public void updateCoppaStatus(int configuration) {
+    switch (configuration) {
+      case RequestConfiguration.TAG_FOR_CHILD_DIRECTED_TREATMENT_TRUE :
+        Vungle.updateUserCoppaStatus(true);
+        break;
+      case RequestConfiguration.TAG_FOR_CHILD_DIRECTED_TREATMENT_FALSE :
+      case RequestConfiguration.TAG_FOR_CHILD_DIRECTED_TREATMENT_UNSPECIFIED :
+        Vungle.updateUserCoppaStatus(false);
+        break;
+      default:
+        //ignore
+        break;
+    }
   }
 
   public interface VungleInitializationListener {

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
@@ -292,6 +292,10 @@ public class VungleMediationAdapter extends RtbAdapter
 
     // Unmute full-screen ads by default.
     mAdConfig = VungleExtrasBuilder.adConfigWithNetworkExtras(mediationExtras, false);
+
+    VungleInitializer.getInstance()
+            .updateCoppaStatus(mediationRewardedAdConfiguration.taggedForChildDirectedTreatment());
+
     VungleInitializer.getInstance()
         .initialize(
             appID,
@@ -474,7 +478,9 @@ public class VungleMediationAdapter extends RtbAdapter
   public void loadRtbRewardedAd(@NonNull MediationRewardedAdConfiguration mediationRewardedAdConfiguration,
       @NonNull MediationAdLoadCallback<MediationRewardedAd, MediationRewardedAdCallback> mediationAdLoadCallback) {
     Log.d(TAG, "loadRtbRewardedAd()...");
-    loadRewardedAd(mediationRewardedAdConfiguration, mediationAdLoadCallback);
+      VungleInitializer.getInstance()
+              .updateCoppaStatus(mediationRewardedAdConfiguration.taggedForChildDirectedTreatment());
+      loadRewardedAd(mediationRewardedAdConfiguration, mediationAdLoadCallback);
   }
 
   @Override
@@ -482,6 +488,8 @@ public class VungleMediationAdapter extends RtbAdapter
       @NonNull MediationInterstitialAdConfiguration mediationInterstitialAdConfiguration,
       @NonNull MediationAdLoadCallback<MediationInterstitialAd, MediationInterstitialAdCallback> mediationAdLoadCallback) {
     Log.d(TAG, "loadRtbInterstitialAd()...");
+    VungleInitializer.getInstance()
+            .updateCoppaStatus(mediationInterstitialAdConfiguration.taggedForChildDirectedTreatment());
     VungleRtbInterstitialAd rtbInterstitialAd = new VungleRtbInterstitialAd(
         mediationInterstitialAdConfiguration, mediationAdLoadCallback);
     rtbInterstitialAd.render();
@@ -492,6 +500,8 @@ public class VungleMediationAdapter extends RtbAdapter
       @NonNull MediationBannerAdConfiguration mediationBannerAdConfiguration,
       @NonNull MediationAdLoadCallback<MediationBannerAd, MediationBannerAdCallback> mediationAdLoadCallback) {
     Log.d(TAG, "loadRtbBannerAd()...");
+    VungleInitializer.getInstance()
+            .updateCoppaStatus(mediationBannerAdConfiguration.taggedForChildDirectedTreatment());
     VungleRtbBannerAd rtbBannerAd = new VungleRtbBannerAd(mediationBannerAdConfiguration,
         mediationAdLoadCallback);
     rtbBannerAd.render();

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/vungle/mediation/VungleInterstitialAdapter.java
@@ -76,6 +76,9 @@ public class VungleInterstitialAdapter
       return;
     }
 
+    VungleInitializer.getInstance()
+            .updateCoppaStatus(mediationAdRequest.taggedForChildDirectedTreatment());
+
     AdapterParametersParser.Config config = AdapterParametersParser.parse(appID, mediationExtras);
     // Unmute full-screen ads by default.
     mAdConfig = VungleExtrasBuilder.adConfigWithNetworkExtras(mediationExtras, false);
@@ -248,6 +251,10 @@ public class VungleInterstitialAdapter
       }
       return;
     }
+
+    VungleInitializer.getInstance()
+            .updateCoppaStatus(mediationAdRequest.taggedForChildDirectedTreatment());
+
     mVungleManager = VungleManager.getInstance();
 
     String placementForPlay = mVungleManager.findPlacement(mediationExtras, serverParameters);


### PR DESCRIPTION
#### Version 6.10.3.0
- Verified compatibility with Vungle SDK 6.10.3.
- Added support for Child-Directed setting (COPPA) to be pass to the Vungle SDK via new API

Built and tested with:
- Google Mobile Ads SDK version 20.5.0.
- Vungle SDK version 6.10.3.