### PR TITLE
fix NendAdLoader typo nendLogoImage to nendAdImage

### DIFF
--- a/ThirdPartyAdapters/nend/nend/src/main/java/com/google/ads/mediation/nend/NativeAdLoader.java
+++ b/ThirdPartyAdapters/nend/nend/src/main/java/com/google/ads/mediation/nend/NativeAdLoader.java
@@ -126,7 +126,7 @@ class NativeAdLoader {
 
     NendNativeMappedImage logoImage = null;
     if (shouldReturnUrlsForImageAssets || nendLogoImage != null) {
-      logoImage = new NendNativeMappedImage(context, nendAdImage, Uri.parse(ad.getLogoImageUrl()));
+      logoImage = new NendNativeMappedImage(context, nendLogoImage, Uri.parse(ad.getLogoImageUrl()));
     }
 
     return new NendUnifiedNativeNormalAdMapper(context, forwarder, ad, adImage, logoImage);


### PR DESCRIPTION
NendAdLoader  has typo . fix that.
fix this [issue #378 ](https://github.com/googleads/googleads-mobile-android-mediation/issues/378).