### PR TITLE
Vungle adapter for SDK V6.10.5

### DIFF
--- a/ThirdPartyAdapters/vungle/CHANGELOG.md
+++ b/ThirdPartyAdapters/vungle/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Vungle Android Mediation Adapter Changelog
 
+#### Version 6.10.5.0
+- Verified compatibility with Vungle SDK 6.10.5
+  SDK V6.10.5 includes fix for crash related to synchronization
+  issue handling gson lib JsonObject
+
 #### Version 6.10.4.0
 - Verified compatibility with Vungle SDK 6.10.4.
 

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -8,7 +8,7 @@ ext {
     // String property to store the proper name of the mediation network adapter.
     adapterName = "Vungle"
     // String property to store version name.
-    stringVersion = "6.10.4.0"
+    stringVersion = "6.10.5.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30
-        versionCode 6100400
+        versionCode 6100500
         versionName stringVersion
         buildConfigField("String", "ADAPTER_VERSION", "\"${stringVersion}\"")
     }
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    implementation ('com.vungle:publisher-sdk-android:6.10.4') {
+    implementation ('com.github.vungle:vungle-android-sdk:6.10.5-RC1') {
         transitive=true
     }
 

--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    implementation ('com.github.vungle:vungle-android-sdk:6.10.5-RC1') {
+    implementation ('com.vungle:publisher-sdk-android:6.10.5') {
         transitive=true
     }
 


### PR DESCRIPTION
Adapter update to simply point to SDK V6.10.5
No adapter changes, and Vungle's SDK has fix for a crash