### PR TITLE
Vungle AdMob adapter 6.11.0.2 release

### DIFF
--- a/ThirdPartyAdapters/vungle/vungle/build.gradle
+++ b/ThirdPartyAdapters/vungle/vungle/build.gradle
@@ -8,7 +8,7 @@ ext {
     // String property to store the proper name of the mediation network adapter.
     adapterName = "Vungle"
     // String property to store version name.
-    stringVersion = "6.11.0.1"
+    stringVersion = "6.11.0.2"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 31
-        versionCode 6110001
+        versionCode 6110002
         versionName stringVersion
         buildConfigField("String", "ADAPTER_VERSION", "\"${stringVersion}\"")
     }

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
@@ -287,6 +287,9 @@ public class VungleMediationAdapter extends RtbAdapter
     }
 
     mAdMarkup = mediationRewardedAdConfiguration.getBidResponse();
+    if (TextUtils.isEmpty(mAdMarkup)) {
+      mAdMarkup = null; // We use null to avoid ""
+    }
     Log.d(TAG, "Render rewarded mAdMarkup=" + mAdMarkup);
 
     // Unmute full-screen ads by default.

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/rtb/VungleRtbBannerAd.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/rtb/VungleRtbBannerAd.java
@@ -95,6 +95,9 @@ public class VungleRtbBannerAd implements MediationBannerAd {
     }
 
     String adMarkup = mediationBannerAdConfiguration.getBidResponse();
+    if (TextUtils.isEmpty(adMarkup)) {
+      adMarkup = null; // We use null to avoid ""
+    }
     Log.d(TAG, "Render banner mAdMarkup=" + adMarkup);
 
     vungleBannerAdapter = new VungleBannerAdapter(placementForPlay, uniqueRequestId, adConfig,

--- a/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/rtb/VungleRtbInterstitialAd.java
+++ b/ThirdPartyAdapters/vungle/vungle/src/main/java/com/google/ads/mediation/vungle/rtb/VungleRtbInterstitialAd.java
@@ -73,6 +73,9 @@ public class VungleRtbInterstitialAd implements MediationInterstitialAd {
     }
 
     mAdMarkup = mediationInterstitialAdConfiguration.getBidResponse();
+    if (TextUtils.isEmpty(mAdMarkup)) {
+      mAdMarkup = null; // We use null to avoid ""
+    }
     Log.d(TAG, "Render interstitial mAdMarkup=" + mAdMarkup);
 
     AdapterParametersParser.Config config = AdapterParametersParser.parse(appID, mediationExtras);


### PR DESCRIPTION
Bugfix: Wrap up the adapter for empty adMarkup issue.