### PR TITLE
Fixed an `Error calling adapter: com.google.ads.mediation.facebook.FacebookMediationAdapter` error that sometimes happens on the first ad request of a session.

### DIFF
--- a/ThirdPartyAdapters/meta/CHANGELOG.md
+++ b/ThirdPartyAdapters/meta/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Next Version
 - Rebranded adapter name to "Meta Audience Network".
 - Removed waterfall integration.
+- Fixed an `Error calling adapter: com.google.ads.mediation.facebook.FacebookMediationAdapter` error that sometimes happens on the first ad request of a session.
 
 #### 6.11.0.1
 - Updated `compileSdkVersion` and `targetSdkVersion` to API 31.

--- a/ThirdPartyAdapters/meta/meta/src/main/java/com/google/ads/mediation/facebook/FacebookInitializer.java
+++ b/ThirdPartyAdapters/meta/meta/src/main/java/com/google/ads/mediation/facebook/FacebookInitializer.java
@@ -4,11 +4,11 @@ import static com.google.ads.mediation.facebook.FacebookMediationAdapter.ERROR_D
 import static com.google.ads.mediation.facebook.FacebookMediationAdapter.ERROR_FACEBOOK_INITIALIZATION;
 
 import android.content.Context;
+import androidx.annotation.NonNull;
 import com.facebook.ads.AudienceNetworkAds;
 import com.facebook.ads.AudienceNetworkAds.InitResult;
 import com.google.android.gms.ads.AdError;
 import java.util.ArrayList;
-
 
 class FacebookInitializer implements AudienceNetworkAds.InitListener {
 
@@ -36,7 +36,8 @@ class FacebookInitializer implements AudienceNetworkAds.InitListener {
     getInstance().initialize(context, placements, listener);
   }
 
-  void initialize(Context context, ArrayList<String> placements, Listener listener) {
+  void initialize(@NonNull Context context, @NonNull ArrayList<String> placements,
+      @NonNull Listener listener) {
     if (mIsInitializing) {
       mListeners.add(listener);
       return;
@@ -48,7 +49,6 @@ class FacebookInitializer implements AudienceNetworkAds.InitListener {
     }
 
     mIsInitializing = true;
-
     getInstance().mListeners.add(listener);
     AudienceNetworkAds.buildInitSettings(context)
         .withMediationService("GOOGLE:" + BuildConfig.ADAPTER_VERSION)

--- a/ThirdPartyAdapters/meta/meta/src/main/java/com/google/ads/mediation/facebook/FacebookMediationAdapter.java
+++ b/ThirdPartyAdapters/meta/meta/src/main/java/com/google/ads/mediation/facebook/FacebookMediationAdapter.java
@@ -217,6 +217,10 @@ public class FacebookMediationAdapter extends RtbAdapter {
             initializationCompleteCallback.onInitializationFailed(error.getMessage());
           }
         });
+
+    // The first call to getBidderToken takes longer than subsequent.
+    // Call it here during initialization so that it returns faster at ad request time.
+    BidderTokenProvider.getBidderToken(context);
   }
 
   @Override
@@ -251,7 +255,8 @@ public class FacebookMediationAdapter extends RtbAdapter {
   }
 
   @Override
-  public void loadRtbNativeAd(@NonNull MediationNativeAdConfiguration mediationNativeAdConfiguration,
+  public void loadRtbNativeAd(
+      @NonNull MediationNativeAdConfiguration mediationNativeAdConfiguration,
       @NonNull MediationAdLoadCallback<UnifiedNativeAdMapper, MediationNativeAdCallback>
           mediationAdLoadCallback) {
     nativeAd = new FacebookRtbNativeAd(mediationNativeAdConfiguration, mediationAdLoadCallback);


### PR DESCRIPTION
Fixed an `Error calling adapter: com.google.ads.mediation.facebook.FacebookMediationAdapter` error that sometimes happens on the first ad request of a session.
