### PR TITLE
Update Chartboost sdk to version 9.3.0

### DIFF
--- a/ThirdPartyAdapters/chartboost/build.gradle
+++ b/ThirdPartyAdapters/chartboost/build.gradle
@@ -17,6 +17,9 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url 'https://cboost.jfrog.io/artifactory/chartboost-ads/'
+        }
     }
 }
 

--- a/ThirdPartyAdapters/chartboost/chartboost/build.gradle
+++ b/ThirdPartyAdapters/chartboost/chartboost/build.gradle
@@ -8,7 +8,7 @@ ext {
     // String property to store the proper name of the mediation network adapter.
     adapterName = "Chartboost"
     // String property to store version name.
-    stringVersion = "9.2.1.1"
+    stringVersion = "9.3.0.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 31
-        versionCode 9020101
+        versionCode 9030000
         versionName stringVersion
         buildConfigField("String", "ADAPTER_VERSION", "\"${stringVersion}\"")
     }
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.chartboost:chartboost-sdk:9.2.1'
+    implementation 'com.chartboost:chartboost-sdk:9.3.0'
     implementation 'androidx.annotation:annotation:1.5.0'
     implementation 'com.google.android.gms:play-services-ads:22.0.0'
 }


### PR DESCRIPTION
Latest version of CB SDK 9.3.0. Doesn't contain any breaking changes but requires
maven {
url 'https://cboost.jfrog.io/artifactory/chartboost-ads/'
}
repository to be added in the gradle to access the sdk.