### PR TITLE
support mediaview of native view clickable

### DIFF
--- a/ThirdPartyAdapters/mintegral/mintegral/src/main/java/com/google/ads/mediation/mintegral/mediation/MintegralNativeAd.java
+++ b/ThirdPartyAdapters/mintegral/mintegral/src/main/java/com/google/ads/mediation/mintegral/mediation/MintegralNativeAd.java
@@ -42,7 +42,6 @@ public abstract class MintegralNativeAd extends UnifiedNativeAdMapper implements
   protected final MediationNativeAdConfiguration adConfiguration;
   protected final MediationAdLoadCallback<UnifiedNativeAdMapper, MediationNativeAdCallback>
       adLoadCallback;
-  protected MediationNativeAdCallback nativeCallback;
   protected static final double MINTEGRAL_SDK_IMAGE_SCALE = 1.0;
   public MintegralNativeAdListener mintegralNativeAdListener;
 

--- a/ThirdPartyAdapters/mintegral/mintegral/src/main/java/com/google/ads/mediation/mintegral/mediation/MintegralNativeAd.java
+++ b/ThirdPartyAdapters/mintegral/mintegral/src/main/java/com/google/ads/mediation/mintegral/mediation/MintegralNativeAd.java
@@ -120,15 +120,15 @@ public abstract class MintegralNativeAd extends UnifiedNativeAdMapper implements
 
   @Override
   public void onEnterFullscreen() {
-    if (nativeCallback != null) {
-      nativeCallback.onAdOpened();
+    if (mintegralNativeAdListener.nativeCallback != null) {
+      mintegralNativeAdListener.nativeCallback.onAdOpened();
     }
   }
 
   @Override
   public void onExitFullscreen() {
-    if (nativeCallback != null) {
-      nativeCallback.onAdClosed();
+    if (mintegralNativeAdListener.nativeCallback != null) {
+      mintegralNativeAdListener.nativeCallback.onAdClosed();
     }
   }
 
@@ -149,15 +149,15 @@ public abstract class MintegralNativeAd extends UnifiedNativeAdMapper implements
 
   @Override
   public void onVideoAdClicked(Campaign campaign) {
-    if (nativeCallback != null) {
-      nativeCallback.reportAdClicked();
+    if (mintegralNativeAdListener.nativeCallback != null) {
+      mintegralNativeAdListener.nativeCallback.reportAdClicked();
     }
   }
 
   @Override
   public void onVideoStart() {
-    if (nativeCallback != null) {
-      nativeCallback.onVideoPlay();
+    if (mintegralNativeAdListener.nativeCallback != null) {
+      mintegralNativeAdListener.nativeCallback.onVideoPlay();
     }
   }
 

--- a/ThirdPartyAdapters/mintegral/mintegral/src/main/java/com/google/ads/mediation/mintegral/mediation/MintegralNativeAdListener.java
+++ b/ThirdPartyAdapters/mintegral/mintegral/src/main/java/com/google/ads/mediation/mintegral/mediation/MintegralNativeAdListener.java
@@ -25,7 +25,6 @@ public class MintegralNativeAdListener extends NativeAdWithCodeListener {
 
   public MintegralNativeAdListener(@NonNull MintegralNativeAd mintegralNativeAd) {
     this.mintegralNativeAd = mintegralNativeAd;
-    this.nativeCallback = mintegralNativeAd.nativeCallback;
     this.adLoadCallback = mintegralNativeAd.adLoadCallback;
   }
 

--- a/ThirdPartyAdapters/mintegral/mintegral/src/main/java/com/google/ads/mediation/mintegral/rtb/MintegralRtbNativeAd.java
+++ b/ThirdPartyAdapters/mintegral/mintegral/src/main/java/com/google/ads/mediation/mintegral/rtb/MintegralRtbNativeAd.java
@@ -30,8 +30,10 @@ import com.google.android.gms.ads.mediation.MediationAdLoadCallback;
 import com.google.android.gms.ads.mediation.MediationNativeAdCallback;
 import com.google.android.gms.ads.mediation.MediationNativeAdConfiguration;
 import com.google.android.gms.ads.mediation.UnifiedNativeAdMapper;
+import com.google.android.gms.ads.nativead.MediaView;
 import com.google.android.gms.ads.nativead.NativeAdAssetNames;
 import com.mbridge.msdk.MBridgeConstans;
+import com.mbridge.msdk.nativex.view.MBMediaView;
 import com.mbridge.msdk.out.MBBidNativeHandler;
 
 import org.json.JSONException;
@@ -93,6 +95,18 @@ public class MintegralRtbNativeAd extends MintegralNativeAd {
     copyClickableAssetViews.remove("3012");
 
     ArrayList<View> assetViews = new ArrayList<>(copyClickableAssetViews.values());
+    for (int i = 0; i < assetViews.size(); i++) {
+      View clickView = assetViews.get(i);
+      if (clickView instanceof MediaView) {
+        MediaView mediaView = (MediaView)clickView;
+        for (int a = 0; a < mediaView.getChildCount(); a++) {
+          View childView = mediaView.getChildAt(a);
+          if(childView instanceof MBMediaView){
+            ((MBMediaView)childView).setOnMediaViewListener(this);
+          }
+        }
+      }
+    }
     if (mbBidNativeHandler != null) {
       mbBidNativeHandler.registerView(view, assetViews, campaign);
     }

--- a/ThirdPartyAdapters/mintegral/mintegral/src/main/java/com/google/ads/mediation/mintegral/rtb/MintegralRtbNativeAd.java
+++ b/ThirdPartyAdapters/mintegral/mintegral/src/main/java/com/google/ads/mediation/mintegral/rtb/MintegralRtbNativeAd.java
@@ -103,8 +103,10 @@ public class MintegralRtbNativeAd extends MintegralNativeAd {
           View childView = mediaView.getChildAt(a);
           if(childView instanceof MBMediaView){
             ((MBMediaView)childView).setOnMediaViewListener(this);
+            break;
           }
         }
+        break;
       }
     }
     if (mbBidNativeHandler != null) {

--- a/ThirdPartyAdapters/mintegral/mintegral/src/main/java/com/google/ads/mediation/mintegral/waterfall/MintegralWaterfallNativeAd.java
+++ b/ThirdPartyAdapters/mintegral/mintegral/src/main/java/com/google/ads/mediation/mintegral/waterfall/MintegralWaterfallNativeAd.java
@@ -26,8 +26,10 @@ import com.google.android.gms.ads.mediation.MediationAdLoadCallback;
 import com.google.android.gms.ads.mediation.MediationNativeAdCallback;
 import com.google.android.gms.ads.mediation.MediationNativeAdConfiguration;
 import com.google.android.gms.ads.mediation.UnifiedNativeAdMapper;
+import com.google.android.gms.ads.nativead.MediaView;
 import com.google.android.gms.ads.nativead.NativeAdAssetNames;
 import com.mbridge.msdk.MBridgeConstans;
+import com.mbridge.msdk.nativex.view.MBMediaView;
 import com.mbridge.msdk.out.MBBidNativeHandler;
 import com.mbridge.msdk.out.MBNativeHandler;
 import java.util.ArrayList;
@@ -78,6 +80,18 @@ public class MintegralWaterfallNativeAd extends MintegralNativeAd {
     copyClickableAssetViews.remove("3012");
 
     ArrayList<View> assetViews = new ArrayList<>(copyClickableAssetViews.values());
+    for (int i = 0; i < assetViews.size(); i++) {
+      View clickView = assetViews.get(i);
+      if (clickView instanceof MediaView) {
+        MediaView mediaView = (MediaView)clickView;
+        for (int a = 0; a < mediaView.getChildCount(); a++) {
+          View childView = mediaView.getChildAt(a);
+          if(childView instanceof MBMediaView){
+            ((MBMediaView)childView).setOnMediaViewListener(this);
+          }
+        }
+      }
+    }
     if (mbNativeHandler != null) {
       mbNativeHandler.registerView(view, assetViews, campaign);
     }

--- a/ThirdPartyAdapters/mintegral/mintegral/src/main/java/com/google/ads/mediation/mintegral/waterfall/MintegralWaterfallNativeAd.java
+++ b/ThirdPartyAdapters/mintegral/mintegral/src/main/java/com/google/ads/mediation/mintegral/waterfall/MintegralWaterfallNativeAd.java
@@ -88,8 +88,10 @@ public class MintegralWaterfallNativeAd extends MintegralNativeAd {
           View childView = mediaView.getChildAt(a);
           if(childView instanceof MBMediaView){
             ((MBMediaView)childView).setOnMediaViewListener(this);
+            break;
           }
         }
+        break;
       }
     }
     if (mbNativeHandler != null) {


### PR DESCRIPTION
In previous versions, due to our failure to handle a series of callbacks related to MBMediaView, events could not be given to the admob sdk through the adapter when interacting with users and MBMediaView.

We have set up listening for MBMediaView this time and also addressed the issue of whether nativeCallback can only have value after the load is completed