### PR TITLE
#Moloco #Adapter Fix the mediation platform name that is set when initializing Moloco SDK.

### DIFF
--- a/ThirdPartyAdapters/moloco/CHANGELOG.md
+++ b/ThirdPartyAdapters/moloco/CHANGELOG.md
@@ -1,4 +1,4 @@
 ## Moloco Android Mediation Adapter Changelog
 
 #### Next Version
-- Initial release.
+- Initial release. Has bidding support for banner, interstitial and rewarded formats.

--- a/ThirdPartyAdapters/moloco/gradle.properties
+++ b/ThirdPartyAdapters/moloco/gradle.properties
@@ -2,4 +2,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 kotlin.code.style=official
-org.gradle.jvmargs=-Xmx1g -Xms1g
+org.gradle.jvmargs=-Xmx2g -Xms1g

--- a/ThirdPartyAdapters/moloco/gradlew.bat
+++ b/ThirdPartyAdapters/moloco/gradlew.bat
@@ -13,6 +13,8 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 @rem
+@rem SPDX-License-Identifier: Apache-2.0
+@rem
 
 @if "%DEBUG%"=="" @echo off
 @rem ##########################################################################
@@ -43,11 +45,11 @@ set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
 if %ERRORLEVEL% equ 0 goto execute
 
-echo.
-echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 
@@ -57,11 +59,11 @@ set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
 if exist "%JAVA_EXE%" goto execute
 
-echo.
-echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 

--- a/ThirdPartyAdapters/moloco/moloco/src/main/kotlin/com/google/ads/mediation/moloco/MolocoMediationAdapter.kt
+++ b/ThirdPartyAdapters/moloco/moloco/src/main/kotlin/com/google/ads/mediation/moloco/MolocoMediationAdapter.kt
@@ -119,7 +119,7 @@ class MolocoMediationAdapter : RtbAdapter() {
       Log.w(TAG, message)
     }
 
-    val mediationInfo = MediationInfo(Companion::class.java.name)
+    val mediationInfo = MediationInfo(MEDIATION_PLATFORM_NAME)
     val initParams = MolocoInitParams(context, appKeyForInit, mediationInfo)
     Moloco.initialize(initParams) { status ->
       if (status.initialization == Initialization.SUCCESS) {
@@ -186,6 +186,7 @@ class MolocoMediationAdapter : RtbAdapter() {
 
   companion object {
     private val TAG = MolocoMediationAdapter::class.simpleName
+    const val MEDIATION_PLATFORM_NAME = "AdMob"
     const val KEY_APP_KEY = "app_key"
     const val KEY_AD_UNIT_ID = "ad_unit_id"
     const val ERROR_CODE_MISSING_APP_KEY = 101

--- a/ThirdPartyAdapters/moloco/moloco/src/test/kotlin/com/google/ads/mediation/moloco/MolocoMediationAdapterTest.kt
+++ b/ThirdPartyAdapters/moloco/moloco/src/test/kotlin/com/google/ads/mediation/moloco/MolocoMediationAdapterTest.kt
@@ -25,6 +25,7 @@ import com.google.ads.mediation.adaptertestkit.AdapterTestKitConstants.TEST_WATE
 import com.google.ads.mediation.adaptertestkit.assertGetSdkVersion
 import com.google.ads.mediation.adaptertestkit.assertGetVersionInfo
 import com.google.ads.mediation.moloco.MolocoAdapterUtils.setMolocoIsAgeRestricted
+import com.google.ads.mediation.moloco.MolocoMediationAdapter.Companion.MEDIATION_PLATFORM_NAME
 import com.google.android.gms.ads.AdError
 import com.google.android.gms.ads.AdFormat
 import com.google.android.gms.ads.AdSize
@@ -43,6 +44,7 @@ import com.google.android.gms.ads.mediation.MediationRewardedAd
 import com.google.android.gms.ads.mediation.MediationRewardedAdCallback
 import com.google.android.gms.ads.mediation.MediationRewardedAdConfiguration
 import com.google.android.gms.ads.mediation.rtb.SignalCallbacks
+import com.google.common.truth.Truth.assertThat
 import com.moloco.sdk.BuildConfig
 import com.moloco.sdk.publisher.Banner
 import com.moloco.sdk.publisher.CreateBannerCallback
@@ -95,6 +97,7 @@ class MolocoMediationAdapterTest {
   private val mockInterstitialAd = mock<InterstitialAd>()
   private val mockRewardedAd = mock<RewardedInterstitialAd>()
   private val mockBannerAd = mock<Banner>()
+  private val molocoInitParamsCaptor = argumentCaptor<MolocoInitParams>()
 
   @Before
   fun setUp() {
@@ -181,8 +184,10 @@ class MolocoMediationAdapterTest {
         listOf(mediationConfiguration),
       )
 
-      mockMoloco.verify { initialize(any(), any()) }
+      mockMoloco.verify { initialize(molocoInitParamsCaptor.capture(), any()) }
     }
+    val molocoInitParams = molocoInitParamsCaptor.firstValue
+    assertThat(molocoInitParams.mediationInfo.name).isEqualTo(MEDIATION_PLATFORM_NAME)
   }
 
   @Test


### PR DESCRIPTION
#Moloco #Adapter Fix the mediation platform name that is set when initializing Moloco SDK.
