### PR TITLE
Liftoff 7.5.0.0 adapter release

### DIFF
--- a/ThirdPartyAdapters/liftoffmonetize/CHANGELOG.md
+++ b/ThirdPartyAdapters/liftoffmonetize/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Liftoff Monetize Android Mediation Adapter Changelog
 
+#### Version 7.5.0.0
+- Updated the minimum required Android API level to 23.
+- Updated the minimum required Google Mobile Ads SDK version to 24.0.0.
+
+Built and tested with:
+- Google Mobile Ads SDK version 24.0.0.
+- Vungle SDK version 7.5.0.
+
 #### Version 7.4.3.1
 - Updated the minimum required Android API level to 23.
 - Updated the minimum required Google Mobile Ads SDK version to 24.0.0.

--- a/ThirdPartyAdapters/liftoffmonetize/liftoffmonetize/build.gradle
+++ b/ThirdPartyAdapters/liftoffmonetize/liftoffmonetize/build.gradle
@@ -12,7 +12,7 @@ ext {
     // String property to store the artifact id.
     stringArtifactId = "vungle"
     // String property to store version name.
-    stringVersion = "7.4.3.1"
+    stringVersion = "7.5.0.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
     // Jacoco version to generate code coverage data
@@ -25,7 +25,7 @@ android {
     defaultConfig {
         minSdkVersion 23
         targetSdk 33
-        versionCode 7040301
+        versionCode 7050000
         versionName stringVersion
         buildConfigField("String", "ADAPTER_VERSION", "\"${stringVersion}\"")
         multiDexEnabled true
@@ -119,7 +119,7 @@ task jacocoTestReport(type: JacocoReport,
 }
 
 dependencies {
-    implementation 'com.vungle:vungle-ads:7.4.3'
+    implementation 'com.vungle:vungle-ads:7.5.0'
     implementation 'androidx.annotation:annotation:1.5.0'
     implementation 'com.google.android.gms:play-services-ads:24.0.0'
 

--- a/ThirdPartyAdapters/liftoffmonetize/liftoffmonetize/src/main/java/com/google/ads/mediation/vungle/VungleInitializer.java
+++ b/ThirdPartyAdapters/liftoffmonetize/liftoffmonetize/src/main/java/com/google/ads/mediation/vungle/VungleInitializer.java
@@ -21,9 +21,9 @@ import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.RequestConfiguration;
 import com.vungle.ads.InitializationListener;
 import com.vungle.ads.VungleAds;
-import com.vungle.ads.VungleAds.WrapperFramework;
 import com.vungle.ads.VungleError;
 import com.vungle.ads.VunglePrivacySettings;
+import com.vungle.ads.VungleWrapperFramework;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -41,7 +41,7 @@ public class VungleInitializer implements InitializationListener {
   private VungleInitializer() {
     initListeners = new ArrayList<>();
     VungleAds.setIntegrationName(
-        WrapperFramework.admob,
+        VungleWrapperFramework.admob,
         com.vungle.mediation.BuildConfig.ADAPTER_VERSION.replace('.', '_'));
   }
 


### PR DESCRIPTION
- Replace class VungleAds.WrapperFramework with VungleWrapperFramework.
- Based on Vungle SDK version 7.5.0.