### PR TITLE
Liftoff 7.6.0 adapter release

### DIFF
--- a/ThirdPartyAdapters/liftoffmonetize/CHANGELOG.md
+++ b/ThirdPartyAdapters/liftoffmonetize/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Liftoff Monetize Android Mediation Adapter Changelog
 
+#### Version 7.6.0.0
+- Verified compatibility with Vungle SDK 7.6.0.
+
+Built and tested with:
+- Google Mobile Ads SDK version 24.5.0.
+- Vungle SDK version 7.6.0.
+
 #### Version 7.5.1.0
 - Verified compatibility with Vungle SDK 7.5.1.
 

--- a/ThirdPartyAdapters/liftoffmonetize/liftoffmonetize/build.gradle
+++ b/ThirdPartyAdapters/liftoffmonetize/liftoffmonetize/build.gradle
@@ -12,7 +12,7 @@ ext {
     // String property to store the artifact id.
     stringArtifactId = "vungle"
     // String property to store version name.
-    stringVersion = "7.5.1.0"
+    stringVersion = "7.6.0.0"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
     // Jacoco version to generate code coverage data
@@ -25,7 +25,7 @@ android {
     defaultConfig {
         minSdkVersion 23
         targetSdk 33
-        versionCode 7050100
+        versionCode 7060000
         versionName stringVersion
         buildConfigField("String", "ADAPTER_VERSION", "\"${stringVersion}\"")
         multiDexEnabled true
@@ -119,7 +119,7 @@ task jacocoTestReport(type: JacocoReport,
 }
 
 dependencies {
-    implementation 'com.vungle:vungle-ads:7.5.1'
+    implementation 'com.vungle:vungle-ads:7.6.0'
     implementation 'androidx.annotation:annotation:1.5.0'
     implementation 'com.google.android.gms:play-services-ads:24.5.0'
 

--- a/ThirdPartyAdapters/liftoffmonetize/liftoffmonetize/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
+++ b/ThirdPartyAdapters/liftoffmonetize/liftoffmonetize/src/main/java/com/google/ads/mediation/vungle/VungleMediationAdapter.java
@@ -59,6 +59,7 @@ import com.google.android.gms.ads.mediation.rtb.RtbSignalData;
 import com.google.android.gms.ads.mediation.rtb.SignalCallbacks;
 import com.vungle.ads.AdConfig;
 import com.vungle.ads.BaseAd;
+import com.vungle.ads.BidTokenCallback;
 import com.vungle.ads.RewardedAd;
 import com.vungle.ads.RewardedAdListener;
 import com.vungle.ads.VungleError;
@@ -199,16 +200,21 @@ public class VungleMediationAdapter extends RtbAdapter implements MediationRewar
   @Override
   public void collectSignals(@NonNull RtbSignalData rtbSignalData,
       @NonNull SignalCallbacks signalCallbacks) {
-    String token = VungleSdkWrapper.delegate.getBiddingToken(rtbSignalData.getContext());
-    if (TextUtils.isEmpty(token)) {
-      AdError error = new AdError(ERROR_CANNOT_GET_BID_TOKEN,
-          "Liftoff Monetize returned an empty bid token.", ERROR_DOMAIN);
-      Log.w(TAG, error.toString());
-      signalCallbacks.onFailure(error);
-    } else {
-      Log.d(TAG, "Liftoff Monetize bidding token=" + token);
-      signalCallbacks.onSuccess(token);
-    }
+    VungleSdkWrapper.delegate.getBiddingToken(rtbSignalData.getContext(), new BidTokenCallback() {
+      @Override
+      public void onBidTokenCollected(@NonNull String token) {
+        Log.d(TAG, "Liftoff Monetize bidding token=" + token);
+        signalCallbacks.onSuccess(token);
+      }
+
+      @Override
+      public void onBidTokenError(@NonNull String s) {
+        AdError error = new AdError(ERROR_CANNOT_GET_BID_TOKEN,
+                "Liftoff Monetize returned an empty bid token.", ERROR_DOMAIN);
+        Log.w(TAG, error.toString());
+        signalCallbacks.onFailure(error);
+      }
+    });
   }
 
   @Override

--- a/ThirdPartyAdapters/liftoffmonetize/liftoffmonetize/src/main/java/com/google/ads/mediation/vungle/VungleSdkWrapper.kt
+++ b/ThirdPartyAdapters/liftoffmonetize/liftoffmonetize/src/main/java/com/google/ads/mediation/vungle/VungleSdkWrapper.kt
@@ -15,6 +15,7 @@
 package com.google.ads.mediation.vungle
 
 import android.content.Context
+import com.vungle.ads.BidTokenCallback
 import com.vungle.ads.InitializationListener
 import com.vungle.ads.VungleAds
 
@@ -31,7 +32,7 @@ object VungleSdkWrapper {
   var delegate =
     object : SdkWrapper {
 
-      override fun getBiddingToken(context: Context): String? = VungleAds.getBiddingToken(context)
+      override fun getBiddingToken(context: Context, callback: BidTokenCallback) = VungleAds.getBiddingToken(context, callback)
 
       override fun getSdkVersion(): String = VungleAds.getSdkVersion()
 
@@ -47,7 +48,7 @@ object VungleSdkWrapper {
 
 /** Declares the methods that will invoke the Liftoff Monetize SDK */
 interface SdkWrapper {
-  fun getBiddingToken(context: Context): String?
+  fun getBiddingToken(context: Context, callback: BidTokenCallback)
 
   fun getSdkVersion(): String
 

--- a/ThirdPartyAdapters/liftoffmonetize/liftoffmonetize/src/main/java/com/google/ads/mediation/vungle/rtb/VungleRtbNativeAd.java
+++ b/ThirdPartyAdapters/liftoffmonetize/liftoffmonetize/src/main/java/com/google/ads/mediation/vungle/rtb/VungleRtbNativeAd.java
@@ -274,6 +274,8 @@ public class VungleRtbNativeAd extends UnifiedNativeAdMapper implements NativeAd
       setIcon(new VungleNativeMappedImage(Uri.parse(iconUrl)));
     }
 
+    setMediaContentAspectRatio(nativeAd.getMediaAspectRatio());
+
     if (runtimeGmaSdkListensToAdapterReportedImpressions()) {
       setOverrideImpressionRecording(true);
     }

--- a/ThirdPartyAdapters/liftoffmonetize/liftoffmonetize/src/test/java/com/google/ads/mediation/vungle/VungleMediationAdapterTest.kt
+++ b/ThirdPartyAdapters/liftoffmonetize/liftoffmonetize/src/test/java/com/google/ads/mediation/vungle/VungleMediationAdapterTest.kt
@@ -56,6 +56,7 @@ import com.google.android.gms.ads.nativead.NativeAdOptions.ADCHOICES_TOP_RIGHT
 import com.google.common.truth.Truth.assertThat
 import com.vungle.ads.AdConfig
 import com.vungle.ads.AdConfig.Companion.LANDSCAPE
+import com.vungle.ads.BidTokenCallback
 import com.vungle.ads.InterstitialAd
 import com.vungle.ads.NativeAd
 import com.vungle.ads.NativeAd.Companion.BOTTOM_LEFT
@@ -75,6 +76,7 @@ import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -1682,7 +1684,10 @@ class VungleMediationAdapterTest {
   @Test
   fun collectSignals_onSuccessCalled() {
     val biddingToken = "token"
-    whenever(mockSdkWrapper.getBiddingToken(any())) doReturn biddingToken
+    whenever(mockSdkWrapper.getBiddingToken(any(), any())).doAnswer {
+      val callback = it.arguments[1] as BidTokenCallback
+      callback.onBidTokenCollected(biddingToken)
+    }
 
     adapter.collectSignals(mockRtbSignalData, mockSignalCallbacks)
 
@@ -1697,7 +1702,10 @@ class VungleMediationAdapterTest {
         "Liftoff Monetize returned an empty bid token.",
         VungleMediationAdapter.ERROR_DOMAIN,
       )
-    whenever(mockSdkWrapper.getBiddingToken(any())) doReturn ""
+    whenever(mockSdkWrapper.getBiddingToken(any(), any())).doAnswer {
+      val callback = it.arguments[1] as BidTokenCallback
+      callback.onBidTokenError("empty bid token")
+    }
 
     adapter.collectSignals(mockRtbSignalData, mockSignalCallbacks)
 


### PR DESCRIPTION
- Compatibility with Vungle SDK 7.6.0
- BidToken API 
- Native ad media view ratio supported.