### PR TITLE
Fix click tracking on content info for Verve native ads

### DIFF
--- a/ThirdPartyAdapters/verve/verve/src/main/kotlin/com/google/ads/mediation/verve/VerveNativeAd.kt
+++ b/ThirdPartyAdapters/verve/verve/src/main/kotlin/com/google/ads/mediation/verve/VerveNativeAd.kt
@@ -93,6 +93,16 @@ internal constructor(
     nonClickableAssetViews: Map<String?, View?>,
   ) {
     hyBidNativeAd?.startTracking(containerView, this)
+
+    clickableAssetViews.values.filterNotNull().forEach { clickableView ->
+      clickableView.setOnClickListener { v ->
+        hyBidNativeAd?.onNativeClick(v)
+        nativeAdCallback?.apply {
+          reportAdClicked()
+          onAdOpened()
+        }
+      }
+    }
   }
 
   override fun untrackView(view: View) {
@@ -101,6 +111,10 @@ internal constructor(
 
   override fun handleClick(view: View) {
     hyBidNativeAd?.onNativeClick(view)
+    nativeAdCallback?.apply {
+      reportAdClicked()
+      onAdOpened()
+    }
   }
 
   private fun mapNativeAd(nativeAd: NativeAd) {
@@ -115,7 +129,7 @@ internal constructor(
     imageView.setImageBitmap(nativeAd.bannerBitmap)
     setMediaView(imageView)
 
-    overrideClickHandling = false
+    overrideClickHandling = true
     overrideImpressionRecording = true
   }
 

--- a/ThirdPartyAdapters/verve/verve/src/test/kotlin/com/google/ads/mediation/verve/VerveNativeAdTest.kt
+++ b/ThirdPartyAdapters/verve/verve/src/test/kotlin/com/google/ads/mediation/verve/VerveNativeAdTest.kt
@@ -79,7 +79,8 @@ class VerveNativeAdTest {
     assertThat(verveNativeAd.starRating).isEqualTo(TEST_RATING.toDouble())
     assertThat(verveNativeAd.icon.drawable).isNotNull()
     assertThat(verveNativeAd.icon.uri.toString()).isEqualTo(TEST_ICON_URL)
-    assertThat(verveNativeAd.overrideClickHandling).isFalse()
+    assertThat(verveNativeAd.overrideClickHandling).isTrue()
+    assertThat(verveNativeAd.overrideImpressionRecording).isTrue()
   }
 
   @Test
@@ -156,6 +157,25 @@ class VerveNativeAdTest {
     verveNativeAd.handleClick(testView)
 
     verify(mockHyBidNativeAd).onNativeClick(testView)
+    verify(mockNativeAdCallback).reportAdClicked()
+    verify(mockNativeAdCallback).onAdOpened()
+  }
+
+  @Test
+  fun trackViews_withClickableView_invokesNativeClickAndCallbacks() {
+    verveNativeAd.onRequestSuccess(mockHyBidNativeAd)
+    val clickableView = View(context)
+
+    verveNativeAd.trackViews(
+      testView,
+      /* clickableAssetViews= */ mapOf("key" to clickableView),
+      /* nonClickableAssetViews= */ mapOf(),
+    )
+    clickableView.performClick()
+
+    verify(mockHyBidNativeAd).onNativeClick(clickableView)
+    verify(mockNativeAdCallback).reportAdClicked()
+    verify(mockNativeAdCallback).onAdOpened()
   }
 
   private companion object {


### PR DESCRIPTION
This PR contains the following changes:

- Override click tracking for VerveNativeAd adapter
- Filter clickable views to differentiate content info click from regular ad click