### PR TITLE
Override UnifiedNativeAdMapper.destroy() for InMobi native ads

### DIFF
--- a/ThirdPartyAdapters/inmobi/CHANGELOG.md
+++ b/ThirdPartyAdapters/inmobi/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## InMobi Android Mediation Adapter Changelog
 
 #### Version 11.4.0.0 (In progress)
+- Override `UnifiedNativeAdMapper.destroy()` to call `InMobiNative.destroy()` when GMA invokes full native ad teardown (`zzdqm.zzd()`). Refresh/swap still uses `untrackView` only; `untrackView` continues to call `unTrackViews()` for re-tracking support.
 
 #### Version 11.3.0.1
 - Maps `AgeRestrictedTreatment` to InMobi's COPPA API.

--- a/ThirdPartyAdapters/inmobi/inmobi/src/main/java/com/google/ads/mediation/inmobi/InMobiUnifiedNativeAdMapper.java
+++ b/ThirdPartyAdapters/inmobi/inmobi/src/main/java/com/google/ads/mediation/inmobi/InMobiUnifiedNativeAdMapper.java
@@ -187,6 +187,11 @@ public class InMobiUnifiedNativeAdMapper extends UnifiedNativeAdMapper {
   }
 
   @Override
+  public void destroy() {
+    inMobiNativeWrapper.destroy();
+  }
+
+  @Override
   public void trackViews(View containerView, Map<String, View> clickableAssetViews,
       Map<String, View> nonclickableAssetViews) {
     setOverrideClickHandling(true);

--- a/ThirdPartyAdapters/inmobi/inmobi/src/test/kotlin/com/google/ads/mediation/inmobi/rtb/InMobiRtbNativeAdTest.kt
+++ b/ThirdPartyAdapters/inmobi/inmobi/src/test/kotlin/com/google/ads/mediation/inmobi/rtb/InMobiRtbNativeAdTest.kt
@@ -158,6 +158,15 @@ class InMobiRtbNativeAdTest {
     verify(wrappedNativeAd).unTrackViews()
   }
 
+  @Test
+  fun destroy_invokesDestroy() {
+    rtbNativeAd.onAdLoadSucceeded(inMobiNativeWrapper.inMobiNative, adMetaInfo)
+
+    rtbNativeAd.inMobiUnifiedNativeAdMapper.destroy()
+
+    verify(wrappedNativeAd).destroy()
+  }
+
   private fun setupWrappedInMobiNativeAd(): Unit {
     whenever(wrappedNativeAd.adCtaText).thenReturn("SomeCtaText")
     whenever(wrappedNativeAd.adDescription).thenReturn("AdDescription")

--- a/ThirdPartyAdapters/inmobi/inmobi/src/test/kotlin/com/google/ads/mediation/inmobi/waterfall/InMobiWaterfallNativeAdTest.kt
+++ b/ThirdPartyAdapters/inmobi/inmobi/src/test/kotlin/com/google/ads/mediation/inmobi/waterfall/InMobiWaterfallNativeAdTest.kt
@@ -159,6 +159,15 @@ class InMobiWaterfallNativeAdTest {
     verify(wrappedNativeAd).unTrackViews()
   }
 
+  @Test
+  fun destroy_invokesDestroy() {
+    waterfallNativeAd.onAdLoadSucceeded(inMobiNativeWrapper.inMobiNative, adMetaInfo)
+
+    waterfallNativeAd.inMobiUnifiedNativeAdMapper.destroy()
+
+    verify(wrappedNativeAd).destroy()
+  }
+
   private fun setupWrappedInMobiNativeAd(): Unit {
     whenever(wrappedNativeAd.adCtaText).thenReturn("SomeCtaText")
     whenever(wrappedNativeAd.adDescription).thenReturn("AdDescription")


### PR DESCRIPTION
## Summary
- Override `InMobiUnifiedNativeAdMapper.destroy()` to call `InMobiNative.destroy()` when GMA invokes full native ad teardown (`zzdqm.zzd()`).
- Keep `untrackView()` mapped to `unTrackViews()` only so feed refresh/swap can re-track the same mapper instance.
- Add unit tests for waterfall and RTB native ad paths.

## Context
GMA calls `untrackView()` on refresh/swap and `destroy()` on full native ad teardown. The base `UnifiedNativeAdMapper.destroy()` is a no-op, and `InMobiNativeWrapper.destroy()` had no adapter call site. This wires the teardown path without breaking re-tracking after refresh.

Related SDK fix: inmobi-marketing/unified-sdk-android#1684 (DI-19122 — OMID session abandon on refresh still handled in SDK).

## Note to Google developers — Banner `destroy()` needed
Native mediation has an explicit per-ad teardown hook (`UnifiedNativeAdMapper.destroy()`), but **banner does not**:

| Format | GMA mediation API (25.4.0) | Teardown hook |
|---|---|---|
| Native | `UnifiedNativeAdMapper` | `destroy()` ✅ |
| Banner | `MediationBannerAd` | **`getView()` only** ❌ |

After banner load, GMA takes the view and never calls back into the adapter to release the underlying ad instance. `InMobiBanner.destroy()` exists in the InMobi SDK, but third-party adapters have no lifecycle method to invoke it when GMA swaps or removes a mediated banner.

**Request:** Please add a `destroy()` (or equivalent per-ad teardown callback) to `MediationBannerAd`, similar to native, so adapters can release SDK resources (OMID sessions, refresh timers, listeners) when GMA tears down or replaces a mediated banner view. Until then, banner cleanup must rely on SDK-side view-detach heuristics, which is less reliable under mediation.

## Test plan
- [x] `./gradlew :ThirdPartyAdapters:inmobi:inmobi:testDebugUnitTest`
- [x] `destroy_invokesDestroy` in `InMobiWaterfallNativeAdTest` and `InMobiRtbNativeAdTest`