### PR TITLE
Chartboost adapter: error reporting and cleanup fixes, HALFPAGE support, CCPA forwarding

### DIFF
--- a/ThirdPartyAdapters/chartboost/CHANGELOG.md
+++ b/ThirdPartyAdapters/chartboost/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Chartboost Android Mediation Adapter Changelog
 
+#### Next version
+- Fixed a bug where calling `show()` on an interstitial or rewarded ad that was no longer cached (for example, because it had already been shown or had expired) failed silently instead of invoking `onAdFailedToShow()`.
+- Fixed a bug where interstitial and rewarded ads were not released after a failed load or show.
+- Fixed a bug where banner ads were never detached from the Chartboost SDK after a load or show failure.
+- Fixed a bug where a GDPR consent change made after the Chartboost SDK had already initialized was not forwarded to the SDK.
+- Fixed a bug where a whitespace-only ad location on a rewarded ad request produced a misleading "session not started" error instead of an invalid location error.
+- Fixed a bug where the rewarded ad's expiration log referred to a banner ad. The expiration log for all three ad formats now includes the expiration reason.
+- Adapter now supports Chartboost's 300x600 half page banner size.
+
 #### Version 9.14.0.0 (In progress)
 
 #### Version 9.13.0.0

--- a/ThirdPartyAdapters/chartboost/CHANGELOG.md
+++ b/ThirdPartyAdapters/chartboost/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed a bug where the rewarded ad's expiration log referred to a banner ad. The expiration log for all three ad formats now includes the expiration reason.
 - Adapter now supports Chartboost's 300x600 half page banner size.
 - Fixed the default ad location used when no Ad Location is set in the AdMob UI. It is now `Default`, matching the name Chartboost aggregates unnamed locations under, instead of `default`.
+- Adapter now automatically forwards CCPA consent found inside `IABUSPrivacy_String` to the Chartboost SDK. A value written by the app's CMP takes precedence over a CCPA consent the app set on the Chartboost SDK itself.
 
 #### Version 9.14.0.0 (In progress)
 

--- a/ThirdPartyAdapters/chartboost/CHANGELOG.md
+++ b/ThirdPartyAdapters/chartboost/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed a bug where a whitespace-only ad location on a rewarded ad request produced a misleading "session not started" error instead of an invalid location error.
 - Fixed a bug where the rewarded ad's expiration log referred to a banner ad. The expiration log for all three ad formats now includes the expiration reason.
 - Adapter now supports Chartboost's 300x600 half page banner size.
+- Fixed the default ad location used when no Ad Location is set in the AdMob UI. It is now `Default`, matching the name Chartboost aggregates unnamed locations under, instead of `default`.
 
 #### Version 9.14.0.0 (In progress)
 

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostAdapterUtils.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostAdapterUtils.java
@@ -27,6 +27,7 @@ import androidx.preference.PreferenceManager;
 import com.chartboost.sdk.Chartboost;
 import com.chartboost.sdk.Mediation;
 import com.chartboost.sdk.ads.Banner;
+import com.chartboost.sdk.privacy.model.CCPA.CCPA_CONSENT;
 import com.chartboost.sdk.privacy.model.COPPA;
 import com.google.ads.mediation.common.AgeRestrictedTreatmentUtils;
 import com.google.android.gms.ads.AdSize;
@@ -71,6 +72,33 @@ class ChartboostAdapterUtils {
    * location under "Default", so this must match that name exactly.
    */
   static final String LOCATION_DEFAULT = "Default";
+
+  /**
+   * Key used by IAB-compliant consent management platforms (CMPs) to write the US Privacy String
+   * to {@link android.content.SharedPreferences}.
+   */
+  static final String KEY_US_PRIVACY_STRING = "IABUSPrivacy_String";
+
+  /** Expected length of a well formed US Privacy String. */
+  private static final int US_PRIVACY_STRING_LENGTH = 4;
+
+  /** Index of the spec version character within the US Privacy String. */
+  private static final int US_PRIVACY_STRING_INDEX_VERSION = 0;
+
+  /** Index of the opt-out-of-sale character within the US Privacy String. */
+  private static final int US_PRIVACY_STRING_INDEX_OPT_OUT_SALE = 2;
+
+  /** The only spec version of the US Privacy String that this adapter understands. */
+  private static final char US_PRIVACY_STRING_VERSION_1 = '1';
+
+  /** Opt-out-of-sale character indicating the user opted out of the sale of their data. */
+  private static final char US_PRIVACY_OPT_OUT_SALE_YES = 'Y';
+
+  /** Opt-out-of-sale character indicating the user did not opt out of the sale of their data. */
+  private static final char US_PRIVACY_OPT_OUT_SALE_NO = 'N';
+
+  /** Opt-out-of-sale character indicating that opt-out of sale does not apply to the user. */
+  private static final char US_PRIVACY_OPT_OUT_SALE_NOT_APPLICABLE = '-';
 
   /**
    * Chartboost mediation object.
@@ -325,6 +353,88 @@ class ChartboostAdapterUtils {
       Log.w(TAG, errorMessage);
       return ConsentResult.UNKNOWN;
     }
+  }
+
+
+  /**
+   * Reads the IAB US Privacy String written by the app's consent management platform (CMP) and
+   * maps it to a Chartboost {@link CCPA_CONSENT} value.
+   *
+   * <p>The US Privacy String is a 4 character string stored under the key {@code
+   * IABUSPrivacy_String}:
+   *
+   * <ul>
+   *   <li>index 0 - the spec version, expected to be {@code '1'}.
+   *   <li>index 1 - whether explicit notice was given.
+   *   <li>index 2 - whether the user opted out of the sale of their data. This is the only
+   *       character this method uses.
+   *   <li>index 3 - whether a limited service provider agreement applies.
+   * </ul>
+   *
+   * <p>Returns {@code null} (no consent signal, so the Chartboost SDK is not called) when the
+   * string is absent, empty, a different length than expected, on an unsupported spec version,
+   * or when the opt-out-of-sale character is {@code '-'} (not applicable) or any other
+   * unrecognized character.
+   *
+   * @param context {@link Context} object of your application.
+   * @return {@link CCPA_CONSENT#OPT_OUT_SALE} if the user opted out of the sale of their data,
+   *     {@link CCPA_CONSENT#OPT_IN_SALE} if the user did not, or {@code null} if no signal could
+   *     be determined.
+   * @see <a
+   *     href="https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/US%20Privacy%20String.md">IAB
+   *     US Privacy String spec</a>
+   */
+  static @Nullable CCPA_CONSENT readUsPrivacyConsent(@NonNull Context context) {
+    SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
+
+    String usPrivacyString = "";
+    try {
+      usPrivacyString = sharedPref.getString(KEY_US_PRIVACY_STRING, "");
+    } catch (ClassCastException exception) {
+      Log.w(
+          TAG,
+          "Could not parse IABUSPrivacy_String as a string. Did your CMP write it correctly?",
+          exception);
+    }
+
+    if (TextUtils.isEmpty(usPrivacyString)) {
+      return null;
+    }
+
+    if (usPrivacyString.length() != US_PRIVACY_STRING_LENGTH) {
+      Log.w(
+          TAG,
+          "Ignoring an IABUSPrivacy_String of length "
+              + usPrivacyString.length()
+              + ". Expected "
+              + US_PRIVACY_STRING_LENGTH
+              + " characters. Did your CMP write it correctly?");
+      return null;
+    }
+
+    if (usPrivacyString.charAt(US_PRIVACY_STRING_INDEX_VERSION) != US_PRIVACY_STRING_VERSION_1) {
+      Log.w(
+          TAG,
+          "Ignoring an IABUSPrivacy_String on unsupported spec version "
+              + usPrivacyString.charAt(US_PRIVACY_STRING_INDEX_VERSION)
+              + ". This adapter only understands version "
+              + US_PRIVACY_STRING_VERSION_1
+              + ".");
+      return null;
+    }
+
+    char optOutOfSale = usPrivacyString.charAt(US_PRIVACY_STRING_INDEX_OPT_OUT_SALE);
+    if (optOutOfSale == US_PRIVACY_OPT_OUT_SALE_YES) {
+      return CCPA_CONSENT.OPT_OUT_SALE;
+    }
+
+    if (optOutOfSale == US_PRIVACY_OPT_OUT_SALE_NO) {
+      return CCPA_CONSENT.OPT_IN_SALE;
+    }
+
+    // optOutOfSale is either US_PRIVACY_OPT_OUT_SALE_NOT_APPLICABLE or an unrecognized
+    // character; either way there is no consent signal to report.
+    return null;
   }
 
   static void updateCoppaStatus(

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostAdapterUtils.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostAdapterUtils.java
@@ -67,9 +67,10 @@ class ChartboostAdapterUtils {
   static final String KEY_AD_LOCATION = "adLocation";
 
   /**
-   * Default location for Chartboost ads.
+   * Default location for Chartboost ads. Chartboost aggregates reporting for ads with no named
+   * location under "Default", so this must match that name exactly.
    */
-  static final String LOCATION_DEFAULT = "default";
+  static final String LOCATION_DEFAULT = "Default";
 
   /**
    * Chartboost mediation object.

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostAdapterUtils.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostAdapterUtils.java
@@ -151,11 +151,15 @@ class ChartboostAdapterUtils {
         new AdSize(
             Banner.BannerSize.LEADERBOARD.getWidth(),
             Banner.BannerSize.LEADERBOARD.getHeight());
+    AdSize halfPageSize =
+        new AdSize(
+            Banner.BannerSize.HALFPAGE.getWidth(), Banner.BannerSize.HALFPAGE.getHeight());
 
     ArrayList<AdSize> potentials = new ArrayList<>();
     potentials.add(standardSize);
     potentials.add(mediumSize);
     potentials.add(leaderboardSize);
+    potentials.add(halfPageSize);
 
     AdSize supportedAdSize = MediationUtils.findClosestSize(context, adSize, potentials);
     if (supportedAdSize == null) {
@@ -168,6 +172,8 @@ class ChartboostAdapterUtils {
       return Banner.BannerSize.MEDIUM;
     } else if (supportedAdSize.equals(leaderboardSize)) {
       return Banner.BannerSize.LEADERBOARD;
+    } else if (supportedAdSize.equals(halfPageSize)) {
+      return Banner.BannerSize.HALFPAGE;
     }
     return null;
   }

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostBannerAd.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostBannerAd.java
@@ -49,6 +49,8 @@ public class ChartboostBannerAd implements MediationBannerAd, BannerCallback {
   /** A container view that holds Chartboost's {@link Banner} view. */
   private FrameLayout bannerContainer;
 
+  private Banner chartboostBannerAd;
+
   private final MediationAdLoadCallback<MediationBannerAd, MediationBannerAdCallback>
       mediationAdLoadCallback;
   private MediationBannerAdCallback bannerAdCallback;
@@ -128,7 +130,7 @@ public class ChartboostBannerAd implements MediationBannerAd, BannerCallback {
     FrameLayout.LayoutParams paramsLayout =
         new FrameLayout.LayoutParams(
             closestSize.getWidthInPixels(context), closestSize.getHeightInPixels(context));
-    Banner chartboostBannerAd =
+    chartboostBannerAd =
         new Banner(
             context,
             location,
@@ -153,6 +155,7 @@ public class ChartboostBannerAd implements MediationBannerAd, BannerCallback {
     if (showError != null) {
       AdError error = ChartboostConstants.createSDKError(showError);
       Log.w(TAG, error.toString());
+      detachChartboostBannerAd();
       return;
     }
 
@@ -173,6 +176,7 @@ public class ChartboostBannerAd implements MediationBannerAd, BannerCallback {
       AdError error = ChartboostConstants.createSDKError(cacheError);
       Log.w(TAG, error.toString());
       mediationAdLoadCallback.onFailure(error);
+      detachChartboostBannerAd();
       return;
     }
 
@@ -204,5 +208,12 @@ public class ChartboostBannerAd implements MediationBannerAd, BannerCallback {
   @Override
   public View getView() {
     return bannerContainer;
+  }
+
+  // Releases the ad once GMA is done with it, on load failure or show failure.
+  private void detachChartboostBannerAd() {
+    if (chartboostBannerAd != null) {
+      chartboostBannerAd.detach();
+    }
   }
 }

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostBannerAd.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostBannerAd.java
@@ -201,7 +201,7 @@ public class ChartboostBannerAd implements MediationBannerAd, BannerCallback {
 
   @Override
   public void onAdExpired(@NonNull final ExpirationEvent expirationEvent) {
-    Log.d(TAG, "Chartboost banner ad Expired.");
+    Log.d(TAG, "Chartboost banner ad expired. Reason: " + expirationEvent.getReason() + ".");
   }
 
   @NonNull

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostInitializer.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostInitializer.java
@@ -25,6 +25,8 @@ import androidx.annotation.VisibleForTesting;
 import com.chartboost.sdk.Chartboost;
 import com.chartboost.sdk.callbacks.StartCallback;
 import com.chartboost.sdk.events.StartError;
+import com.chartboost.sdk.privacy.model.CCPA;
+import com.chartboost.sdk.privacy.model.CCPA.CCPA_CONSENT;
 import com.chartboost.sdk.privacy.model.DataUseConsent;
 import com.chartboost.sdk.privacy.model.GDPR;
 import com.chartboost.sdk.privacy.model.GDPR.GDPR_CONSENT;
@@ -54,6 +56,7 @@ public class ChartboostInitializer {
   public void initialize(@NonNull final Context context,
       @NonNull ChartboostParams chartboostParams, @NonNull final Listener listener) {
     applyGdprConsent(context);
+    applyUsPrivacyConsent(context);
 
     if (isInitializing) {
       initListeners.add(listener);
@@ -103,6 +106,16 @@ public class ChartboostInitializer {
       Chartboost.addDataUseConsent(context, dataUseConsent);
     } else if (consentResult == ChartboostAdapterUtils.ConsentResult.FALSE) {
       DataUseConsent dataUseConsent = new GDPR(GDPR_CONSENT.NON_BEHAVIORAL);
+      Chartboost.addDataUseConsent(context, dataUseConsent);
+    }
+  }
+
+  // Runs on every initialize call, not just the first, so a consent change made mid session is
+  // not dropped by the early returns.
+  private void applyUsPrivacyConsent(@NonNull Context context) {
+    CCPA_CONSENT consent = ChartboostAdapterUtils.readUsPrivacyConsent(context);
+    if (consent != null) {
+      DataUseConsent dataUseConsent = new CCPA(consent);
       Chartboost.addDataUseConsent(context, dataUseConsent);
     }
   }

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostInitializer.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostInitializer.java
@@ -53,6 +53,8 @@ public class ChartboostInitializer {
 
   public void initialize(@NonNull final Context context,
       @NonNull ChartboostParams chartboostParams, @NonNull final Listener listener) {
+    applyGdprConsent(context);
+
     if (isInitializing) {
       initListeners.add(listener);
       return;
@@ -65,16 +67,6 @@ public class ChartboostInitializer {
 
     isInitializing = true;
     initListeners.add(listener);
-
-    ConsentResult consentResult =
-        ChartboostAdapterUtils.hasACConsent(context, AD_TECHNOLOGY_PROVIDER_ID);
-    if (consentResult == ChartboostAdapterUtils.ConsentResult.TRUE) {
-      DataUseConsent dataUseConsent = new GDPR(GDPR_CONSENT.BEHAVIORAL);
-      Chartboost.addDataUseConsent(context, dataUseConsent);
-    } else if (consentResult == ChartboostAdapterUtils.ConsentResult.FALSE) {
-      DataUseConsent dataUseConsent = new GDPR(GDPR_CONSENT.NON_BEHAVIORAL);
-      Chartboost.addDataUseConsent(context, dataUseConsent);
-    }
 
     ChartboostAdapterUtils.updateCoppaStatus(context, MobileAds.getRequestConfiguration());
     Chartboost.startWithAppId(context, chartboostParams.getAppId(),
@@ -99,6 +91,20 @@ public class ChartboostInitializer {
             initListeners.clear();
           }
         });
+  }
+
+  // Runs on every initialize call, not just the first, so a consent change made mid session is
+  // not dropped by the early returns.
+  private void applyGdprConsent(@NonNull Context context) {
+    ConsentResult consentResult =
+        ChartboostAdapterUtils.hasACConsent(context, AD_TECHNOLOGY_PROVIDER_ID);
+    if (consentResult == ChartboostAdapterUtils.ConsentResult.TRUE) {
+      DataUseConsent dataUseConsent = new GDPR(GDPR_CONSENT.BEHAVIORAL);
+      Chartboost.addDataUseConsent(context, dataUseConsent);
+    } else if (consentResult == ChartboostAdapterUtils.ConsentResult.FALSE) {
+      DataUseConsent dataUseConsent = new GDPR(GDPR_CONSENT.NON_BEHAVIORAL);
+      Chartboost.addDataUseConsent(context, dataUseConsent);
+    }
   }
 
   interface Listener {

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostInterstitialAd.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostInterstitialAd.java
@@ -135,6 +135,8 @@ public class ChartboostInterstitialAd implements MediationInterstitialAd, Inters
     if (interstitialAdCallback != null) {
       interstitialAdCallback.onAdClosed();
     }
+    // Intentionally not destroyed here. Destroying from inside onAdDismiss makes
+    // the SDK report a second close to the publisher.
   }
 
   @Override
@@ -158,6 +160,7 @@ public class ChartboostInterstitialAd implements MediationInterstitialAd, Inters
       if (interstitialAdCallback != null) {
         interstitialAdCallback.onAdFailedToShow(error);
       }
+      destroyChartboostInterstitialAd();
     }
   }
 
@@ -179,6 +182,7 @@ public class ChartboostInterstitialAd implements MediationInterstitialAd, Inters
       if (mediationAdLoadCallback != null) {
         mediationAdLoadCallback.onFailure(error);
       }
+      destroyChartboostInterstitialAd();
     }
   }
 
@@ -198,5 +202,12 @@ public class ChartboostInterstitialAd implements MediationInterstitialAd, Inters
   @Override
   public void onAdExpired(@NonNull final ExpirationEvent expirationEvent) {
     Log.d(TAG, "Chartboost interstitial ad Expired.");
+  }
+
+  // Releases the ad once GMA is done with it, on load failure or show failure.
+  private void destroyChartboostInterstitialAd() {
+    if (chartboostInterstitialAd != null) {
+      chartboostInterstitialAd.destroy();
+    }
   }
 }

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostInterstitialAd.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostInterstitialAd.java
@@ -201,7 +201,7 @@ public class ChartboostInterstitialAd implements MediationInterstitialAd, Inters
 
   @Override
   public void onAdExpired(@NonNull final ExpirationEvent expirationEvent) {
-    Log.d(TAG, "Chartboost interstitial ad Expired.");
+    Log.d(TAG, "Chartboost interstitial ad expired. Reason: " + expirationEvent.getReason() + ".");
   }
 
   // Releases the ad once GMA is done with it, on load failure or show failure.

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostInterstitialAd.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostInterstitialAd.java
@@ -96,11 +96,14 @@ public class ChartboostInterstitialAd implements MediationInterstitialAd, Inters
 
   @Override
   public void showAd(@NonNull Context context) {
-    if (chartboostInterstitialAd == null || !chartboostInterstitialAd.isCached()) {
+    if (chartboostInterstitialAd == null) {
       AdError error =
           ChartboostConstants.createAdapterError(
               ERROR_AD_NOT_READY, "Chartboost interstitial ad is not yet ready to be shown.");
       Log.w(TAG, error.toString());
+      if (interstitialAdCallback != null) {
+        interstitialAdCallback.onAdFailedToShow(error);
+      }
       return;
     }
     chartboostInterstitialAd.show();

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostMediationAdapter.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostMediationAdapter.java
@@ -56,10 +56,6 @@ public class ChartboostMediationAdapter extends Adapter {
 
   static final String TAG = ChartboostMediationAdapter.class.getSimpleName();
 
-  private ChartboostBannerAd bannerAd;
-  private ChartboostInterstitialAd interstitialAd;
-  private ChartboostRewardedAd rewardedAd;
-
   /**
    * Preferred Chartboost App ID.
    */
@@ -213,7 +209,7 @@ public class ChartboostMediationAdapter extends Adapter {
       @NonNull MediationRewardedAdConfiguration mediationRewardedAdConfiguration,
       @NonNull MediationAdLoadCallback<MediationRewardedAd, MediationRewardedAdCallback>
           mediationAdLoadCallback) {
-    rewardedAd = new ChartboostRewardedAd(mediationAdLoadCallback);
+    ChartboostRewardedAd rewardedAd = new ChartboostRewardedAd(mediationAdLoadCallback);
     rewardedAd.loadAd(mediationRewardedAdConfiguration);
   }
 
@@ -221,14 +217,14 @@ public class ChartboostMediationAdapter extends Adapter {
   public void loadInterstitialAd(
       @NonNull MediationInterstitialAdConfiguration mediationInterstitialAdConfiguration,
       @NonNull MediationAdLoadCallback<MediationInterstitialAd, MediationInterstitialAdCallback> mediationAdLoadCallback) {
-    interstitialAd = new ChartboostInterstitialAd(mediationAdLoadCallback);
+    ChartboostInterstitialAd interstitialAd = new ChartboostInterstitialAd(mediationAdLoadCallback);
     interstitialAd.loadAd(mediationInterstitialAdConfiguration);
   }
 
   @Override
   public void loadBannerAd(@NonNull MediationBannerAdConfiguration mediationBannerAdConfiguration,
       @NonNull MediationAdLoadCallback<MediationBannerAd, MediationBannerAdCallback> mediationAdLoadCallback) {
-    bannerAd = new ChartboostBannerAd(mediationAdLoadCallback);
+    ChartboostBannerAd bannerAd = new ChartboostBannerAd(mediationAdLoadCallback);
     bannerAd.loadAd(mediationBannerAdConfiguration);
   }
 

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostRewardedAd.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostRewardedAd.java
@@ -208,7 +208,7 @@ public class ChartboostRewardedAd implements MediationRewardedAd, RewardedCallba
 
   @Override
   public void onAdExpired(@NonNull final ExpirationEvent expirationEvent) {
-    Log.d(TAG, "Chartboost banner ad Expired.");
+    Log.d(TAG, "Chartboost rewarded ad expired. Reason: " + expirationEvent.getReason() + ".");
   }
 
   // Releases the ad once GMA is done with it, on load failure or show failure.

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostRewardedAd.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostRewardedAd.java
@@ -129,6 +129,8 @@ public class ChartboostRewardedAd implements MediationRewardedAd, RewardedCallba
     if (rewardedAdCallback != null) {
       rewardedAdCallback.onAdClosed();
     }
+    // Intentionally not destroyed here. Destroying from inside onAdDismiss makes
+    // the SDK report a second close to the publisher.
   }
 
   @Override
@@ -153,6 +155,7 @@ public class ChartboostRewardedAd implements MediationRewardedAd, RewardedCallba
       if (rewardedAdCallback != null) {
         rewardedAdCallback.onAdFailedToShow(error);
       }
+      destroyChartboostRewardedAd();
     }
   }
 
@@ -174,6 +177,7 @@ public class ChartboostRewardedAd implements MediationRewardedAd, RewardedCallba
       if (mediationAdLoadCallback != null) {
         mediationAdLoadCallback.onFailure(error);
       }
+      destroyChartboostRewardedAd();
     }
   }
 
@@ -193,5 +197,12 @@ public class ChartboostRewardedAd implements MediationRewardedAd, RewardedCallba
   @Override
   public void onAdExpired(@NonNull final ExpirationEvent expirationEvent) {
     Log.d(TAG, "Chartboost banner ad Expired.");
+  }
+
+  // Releases the ad once GMA is done with it, on load failure or show failure.
+  private void destroyChartboostRewardedAd() {
+    if (chartboostRewardedAd != null) {
+      chartboostRewardedAd.destroy();
+    }
   }
 }

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostRewardedAd.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostRewardedAd.java
@@ -101,11 +101,14 @@ public class ChartboostRewardedAd implements MediationRewardedAd, RewardedCallba
 
   @Override
   public void showAd(@NonNull Context context) {
-    if (chartboostRewardedAd == null || !chartboostRewardedAd.isCached()) {
+    if (chartboostRewardedAd == null) {
       AdError error =
           ChartboostConstants.createAdapterError(
               ERROR_AD_NOT_READY, "Chartboost rewarded ad is not yet ready to be shown.");
       Log.w(TAG, error.toString());
+      if (rewardedAdCallback != null) {
+        rewardedAdCallback.onAdFailedToShow(error);
+      }
       return;
     }
     chartboostRewardedAd.show();

--- a/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostRewardedAd.java
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/main/java/com/google/ads/mediation/chartboost/ChartboostRewardedAd.java
@@ -20,6 +20,7 @@ import static com.google.ads.mediation.chartboost.ChartboostMediationAdapter.TAG
 
 import android.content.Context;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -83,12 +84,7 @@ public class ChartboostRewardedAd implements MediationRewardedAd, RewardedCallba
             new ChartboostInitializer.Listener() {
               @Override
               public void onInitializationSucceeded() {
-                chartboostRewardedAd =
-                    new Rewarded(
-                        location,
-                        ChartboostRewardedAd.this,
-                        ChartboostAdapterUtils.getChartboostMediation());
-                chartboostRewardedAd.cache();
+                createAndLoadRewardedAd(location);
               }
 
               @Override
@@ -112,6 +108,22 @@ public class ChartboostRewardedAd implements MediationRewardedAd, RewardedCallba
       return;
     }
     chartboostRewardedAd.show();
+  }
+
+  private void createAndLoadRewardedAd(@Nullable String location) {
+    if (TextUtils.isEmpty(location)) {
+      AdError error =
+          ChartboostConstants.createAdapterError(
+              ERROR_INVALID_SERVER_PARAMETERS, "Missing or invalid location.");
+      Log.w(TAG, error.toString());
+      mediationAdLoadCallback.onFailure(error);
+      return;
+    }
+
+    chartboostRewardedAd =
+        new Rewarded(
+            location, ChartboostRewardedAd.this, ChartboostAdapterUtils.getChartboostMediation());
+    chartboostRewardedAd.cache();
   }
 
   @Override

--- a/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostAdapterUtilsTest.kt
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostAdapterUtilsTest.kt
@@ -22,10 +22,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.chartboost.sdk.Chartboost
 import com.chartboost.sdk.Mediation
 import com.chartboost.sdk.ads.Banner
+import com.chartboost.sdk.privacy.model.CCPA.CCPA_CONSENT
 import com.chartboost.sdk.privacy.model.COPPA
 import com.google.ads.mediation.chartboost.ChartboostAdapterUtils.KEY_AD_LOCATION
 import com.google.ads.mediation.chartboost.ChartboostAdapterUtils.KEY_APP_ID
 import com.google.ads.mediation.chartboost.ChartboostAdapterUtils.KEY_APP_SIGNATURE
+import com.google.ads.mediation.chartboost.ChartboostAdapterUtils.KEY_US_PRIVACY_STRING
 import com.google.ads.mediation.chartboost.ChartboostAdapterUtils.LOCATION_DEFAULT
 import com.google.ads.mediation.chartboost.ChartboostConstants.AD_TECHNOLOGY_PROVIDER_ID
 import com.google.android.gms.ads.AdSize
@@ -550,6 +552,97 @@ class ChartboostAdapterUtilsTest {
     val consentResult = ChartboostAdapterUtils.hasACConsent(context, AD_TECHNOLOGY_PROVIDER_ID)
 
     assertThat(consentResult).isEqualTo(ChartboostAdapterUtils.ConsentResult.FALSE)
+  }
+
+  // endregion
+
+  // region readUsPrivacyConsent() Tests
+  @Test
+  fun readUsPrivacyConsent_optOutSaleIsY_returnsOptOutSale() {
+    sharedPreferences.stub { on { getString(eq(KEY_US_PRIVACY_STRING), any()) } doReturn "1YYN" }
+
+    val consent = ChartboostAdapterUtils.readUsPrivacyConsent(context)
+
+    assertThat(consent).isEqualTo(CCPA_CONSENT.OPT_OUT_SALE)
+  }
+
+  @Test
+  fun readUsPrivacyConsent_optOutSaleIsN_returnsOptInSale() {
+    sharedPreferences.stub { on { getString(eq(KEY_US_PRIVACY_STRING), any()) } doReturn "1YNN" }
+
+    val consent = ChartboostAdapterUtils.readUsPrivacyConsent(context)
+
+    assertThat(consent).isEqualTo(CCPA_CONSENT.OPT_IN_SALE)
+  }
+
+  @Test
+  fun readUsPrivacyConsent_optOutSaleIsNotApplicable_returnsNull() {
+    sharedPreferences.stub { on { getString(eq(KEY_US_PRIVACY_STRING), any()) } doReturn "1---" }
+
+    val consent = ChartboostAdapterUtils.readUsPrivacyConsent(context)
+
+    assertThat(consent).isNull()
+  }
+
+  @Test
+  fun readUsPrivacyConsent_onlyOptOutSaleCharacterDiffers_stillMapsCorrectly() {
+    // "1YYN" and "1YNN" differ only at index 2, the opt-out-of-sale character. If the reader
+    // were off by one, these two strings would resolve to the same consent value.
+    sharedPreferences.stub { on { getString(eq(KEY_US_PRIVACY_STRING), any()) } doReturn "1YYN" }
+    val optOutSaleConsent = ChartboostAdapterUtils.readUsPrivacyConsent(context)
+
+    sharedPreferences.stub { on { getString(eq(KEY_US_PRIVACY_STRING), any()) } doReturn "1YNN" }
+    val optInSaleConsent = ChartboostAdapterUtils.readUsPrivacyConsent(context)
+
+    assertThat(optOutSaleConsent).isNotEqualTo(optInSaleConsent)
+  }
+
+  @Test
+  fun readUsPrivacyConsent_keyAbsent_returnsNull() {
+    // getString() is never stubbed, so Mockito returns null. A real SharedPreferences returns the
+    // default ("") for an absent key, so this pins the null guard that protects the length check.
+
+    val consent = ChartboostAdapterUtils.readUsPrivacyConsent(context)
+
+    assertThat(consent).isNull()
+  }
+
+  @Test
+  fun readUsPrivacyConsent_emptyString_returnsNull() {
+    sharedPreferences.stub { on { getString(eq(KEY_US_PRIVACY_STRING), any()) } doReturn "" }
+
+    val consent = ChartboostAdapterUtils.readUsPrivacyConsent(context)
+
+    assertThat(consent).isNull()
+  }
+
+  @Test
+  fun readUsPrivacyConsent_tooShort_returnsNull() {
+    sharedPreferences.stub { on { getString(eq(KEY_US_PRIVACY_STRING), any()) } doReturn "1Y" }
+
+    val consent = ChartboostAdapterUtils.readUsPrivacyConsent(context)
+
+    assertThat(consent).isNull()
+  }
+
+  @Test
+  fun readUsPrivacyConsent_wrongSpecVersion_returnsNull() {
+    sharedPreferences.stub { on { getString(eq(KEY_US_PRIVACY_STRING), any()) } doReturn "2YNN" }
+
+    val consent = ChartboostAdapterUtils.readUsPrivacyConsent(context)
+
+    assertThat(consent).isNull()
+  }
+
+  @Test
+  fun readUsPrivacyConsent_valueStoredWithWrongType_returnsNullWithoutCrashing() {
+    sharedPreferences.stub {
+      on { getString(eq(KEY_US_PRIVACY_STRING), any()) } doThrow ClassCastException::class
+    }
+
+    val consent = ChartboostAdapterUtils.readUsPrivacyConsent(context)
+
+    assertThat(consent).isNull()
   }
 
   // endregion

--- a/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostAdapterUtilsTest.kt
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostAdapterUtilsTest.kt
@@ -85,6 +85,13 @@ class ChartboostAdapterUtilsTest {
   }
 
   @Test
+  fun locationDefault_matchesChartboostReportingBucketName() {
+    // Pinned to the literal rather than the constant. Chartboost aggregates unnamed locations
+    // under "Default", so a change in case here silently splits publisher reporting.
+    assertThat(LOCATION_DEFAULT).isEqualTo("Default")
+  }
+
+  @Test
   fun createChartboostParams_withWhitespace_trimsValues() {
     val serverParameters =
       bundleOf(

--- a/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostAdapterUtilsTest.kt
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostAdapterUtilsTest.kt
@@ -196,6 +196,20 @@ class ChartboostAdapterUtilsTest {
   }
 
   @Test
+  fun findClosestBannerSize_halfPageSize_returnsHalfPageBannerSize() {
+    val halfPage = AdSize(300, 600)
+    mockStatic(MediationUtils::class.java).use { mockMediationUtils ->
+      mockMediationUtils
+        .`when`<AdSize> { MediationUtils.findClosestSize(eq(appContext), eq(halfPage), any()) }
+        .thenAnswer { (it.arguments[2] as List<AdSize>)[3] }
+
+      val bannerSize = ChartboostAdapterUtils.findClosestBannerSize(appContext, halfPage)
+
+      assertThat(bannerSize).isEqualTo(Banner.BannerSize.HALFPAGE)
+    }
+  }
+
+  @Test
   fun findClosestBannerSize_unsupportedSize_returnsNull() {
     val unsupportedSize = AdSize(123, 456)
     mockStatic(MediationUtils::class.java).use { mockMediationUtils ->

--- a/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostBannerAdTest.kt
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostBannerAdTest.kt
@@ -271,6 +271,31 @@ class ChartboostBannerAdTest {
   }
 
   @Test
+  fun onAdLoaded_withoutCacheError_doesNotDetachBannerAd() {
+    val serverParameters =
+      bundleOf(
+        KEY_APP_ID to TEST_APP_ID,
+        KEY_APP_SIGNATURE to TEST_APP_SIGNATURE,
+        KEY_AD_LOCATION to TEST_LOCATION,
+      )
+    val config =
+      createMediationBannerAdConfiguration(
+        context = context,
+        serverParameters = serverParameters,
+        adSize = AdSize.BANNER,
+      )
+
+    mockConstruction(Banner::class.java).use { mockedBannerConstruction ->
+      bannerAd.loadAd(config)
+      val createdBanner = mockedBannerConstruction.constructed().first()
+
+      bannerAd.onAdLoaded(cacheEvent, null)
+
+      verify(createdBanner, never()).detach()
+    }
+  }
+
+  @Test
   fun onAdLoaded_withCacheError_invokesOnFailure() {
     whenever(cacheError.code) doReturn cacheErrorCode
     whenever(cacheErrorCode.errorCode) doReturn ERROR_CODE
@@ -284,12 +309,65 @@ class ChartboostBannerAdTest {
   }
 
   @Test
+  fun onAdLoaded_withCacheError_detachesBannerAd() {
+    val serverParameters =
+      bundleOf(
+        KEY_APP_ID to TEST_APP_ID,
+        KEY_APP_SIGNATURE to TEST_APP_SIGNATURE,
+        KEY_AD_LOCATION to TEST_LOCATION,
+      )
+    val config =
+      createMediationBannerAdConfiguration(
+        context = context,
+        serverParameters = serverParameters,
+        adSize = AdSize.BANNER,
+      )
+    whenever(cacheError.code) doReturn cacheErrorCode
+    whenever(cacheErrorCode.errorCode) doReturn ERROR_CODE
+    whenever(cacheError.toString()) doReturn ERROR_MESSAGE
+
+    mockConstruction(Banner::class.java).use { mockedBannerConstruction ->
+      bannerAd.loadAd(config)
+      val createdBanner = mockedBannerConstruction.constructed().first()
+
+      bannerAd.onAdLoaded(cacheEvent, cacheError)
+
+      verify(createdBanner).detach()
+    }
+  }
+
+  @Test
   fun onAdShown_success_invokesOnAdOpened() {
     bannerAd.onAdLoaded(cacheEvent, null)
 
     bannerAd.onAdShown(showEvent, null)
 
     verify(bannerAdCallback).onAdOpened()
+  }
+
+  @Test
+  fun onAdShown_withoutShowError_doesNotDetachBannerAd() {
+    val serverParameters =
+      bundleOf(
+        KEY_APP_ID to TEST_APP_ID,
+        KEY_APP_SIGNATURE to TEST_APP_SIGNATURE,
+        KEY_AD_LOCATION to TEST_LOCATION,
+      )
+    val config =
+      createMediationBannerAdConfiguration(
+        context = context,
+        serverParameters = serverParameters,
+        adSize = AdSize.BANNER,
+      )
+
+    mockConstruction(Banner::class.java).use { mockedBannerConstruction ->
+      bannerAd.loadAd(config)
+      val createdBanner = mockedBannerConstruction.constructed().first()
+
+      bannerAd.onAdShown(showEvent, null)
+
+      verify(createdBanner, never()).detach()
+    }
   }
 
   @Test
@@ -302,6 +380,34 @@ class ChartboostBannerAdTest {
     bannerAd.onAdShown(showEvent, showError)
 
     verify(bannerAdCallback, never()).onAdOpened()
+  }
+
+  @Test
+  fun onAdShown_withShowError_detachesBannerAd() {
+    val serverParameters =
+      bundleOf(
+        KEY_APP_ID to TEST_APP_ID,
+        KEY_APP_SIGNATURE to TEST_APP_SIGNATURE,
+        KEY_AD_LOCATION to TEST_LOCATION,
+      )
+    val config =
+      createMediationBannerAdConfiguration(
+        context = context,
+        serverParameters = serverParameters,
+        adSize = AdSize.BANNER,
+      )
+    whenever(showError.code) doReturn showErrorCode
+    whenever(showErrorCode.errorCode) doReturn ERROR_CODE
+    whenever(showError.toString()) doReturn ERROR_MESSAGE
+
+    mockConstruction(Banner::class.java).use { mockedBannerConstruction ->
+      bannerAd.loadAd(config)
+      val createdBanner = mockedBannerConstruction.constructed().first()
+
+      bannerAd.onAdShown(showEvent, showError)
+
+      verify(createdBanner).detach()
+    }
   }
 
   @Test

--- a/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostBannerAdTest.kt
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostBannerAdTest.kt
@@ -31,6 +31,7 @@ import com.chartboost.sdk.events.ImpressionEvent
 import com.chartboost.sdk.events.ShowError
 import com.chartboost.sdk.events.ShowEvent
 import com.chartboost.sdk.events.StartError
+import com.chartboost.sdk.internal.caching.ExpirationReason
 import com.google.ads.mediation.adaptertestkit.AdErrorMatcher
 import com.google.ads.mediation.adaptertestkit.createMediationBannerAdConfiguration
 import com.google.ads.mediation.chartboost.ChartboostAdapterUtils.KEY_AD_LOCATION
@@ -447,6 +448,8 @@ class ChartboostBannerAdTest {
 
   @Test
   fun onAdExpired_doesNotThrow() {
+    whenever(expirationEvent.reason) doReturn ExpirationReason.TTL_EXPIRED
+
     bannerAd.onAdExpired(expirationEvent)
   }
 

--- a/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostInitializerTest.kt
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostInitializerTest.kt
@@ -207,6 +207,65 @@ class ChartboostInitializerTest {
   }
 
   @Test
+  fun initialize_calledWhileAlreadyInitialized_appliesGdprConsentAgain() {
+    mockStatic(ChartboostAdapterUtils::class.java).use { mockAdapterUtils ->
+      mockAdapterUtils
+        .`when`<ChartboostAdapterUtils.ConsentResult> {
+          ChartboostAdapterUtils.hasACConsent(any(), eq(AD_TECHNOLOGY_PROVIDER_ID))
+        }
+        .thenReturn(
+          ChartboostAdapterUtils.ConsentResult.TRUE,
+          ChartboostAdapterUtils.ConsentResult.FALSE,
+        )
+
+      // First initialization succeeds, leaving the initializer in the isInitialized state.
+      val callbackCaptor = argumentCaptor<StartCallback>()
+      ChartboostInitializer.getInstance().initialize(context, chartboostParams, listener)
+      mockChartboost.verify {
+        Chartboost.startWithAppId(any(), any(), any(), callbackCaptor.capture())
+      }
+      callbackCaptor.firstValue.onStartCompleted(null)
+
+      // Second call hits the isInitialized early return, but consent must still be applied.
+      val gdprCaptor = argumentCaptor<GDPR>()
+      ChartboostInitializer.getInstance().initialize(context, chartboostParams, listener2)
+
+      mockChartboost.verify(
+        { Chartboost.addDataUseConsent(eq(context), gdprCaptor.capture()) },
+        times(2),
+      )
+      assertThat(gdprCaptor.secondValue.consent).isEqualTo(GDPR.GDPR_CONSENT.NON_BEHAVIORAL.value)
+    }
+  }
+
+  @Test
+  fun initialize_calledWhileAlreadyInitializing_appliesGdprConsentAgain() {
+    mockStatic(ChartboostAdapterUtils::class.java).use { mockAdapterUtils ->
+      mockAdapterUtils
+        .`when`<ChartboostAdapterUtils.ConsentResult> {
+          ChartboostAdapterUtils.hasACConsent(any(), eq(AD_TECHNOLOGY_PROVIDER_ID))
+        }
+        .thenReturn(
+          ChartboostAdapterUtils.ConsentResult.TRUE,
+          ChartboostAdapterUtils.ConsentResult.FALSE,
+        )
+
+      // Start first initialization and leave it in progress (isInitializing stays true).
+      ChartboostInitializer.getInstance().initialize(context, chartboostParams, listener)
+
+      // Second call hits the isInitializing early return, but consent must still be applied.
+      val gdprCaptor = argumentCaptor<GDPR>()
+      ChartboostInitializer.getInstance().initialize(context, chartboostParams, listener2)
+
+      mockChartboost.verify(
+        { Chartboost.addDataUseConsent(eq(context), gdprCaptor.capture()) },
+        times(2),
+      )
+      assertThat(gdprCaptor.secondValue.consent).isEqualTo(GDPR.GDPR_CONSENT.NON_BEHAVIORAL.value)
+    }
+  }
+
+  @Test
   fun initialize_withACConsentTrue_addsBehavioralConsent() {
     mockStatic(ChartboostAdapterUtils::class.java).use { mockAdapterUtils ->
       mockAdapterUtils

--- a/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostInitializerTest.kt
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostInitializerTest.kt
@@ -20,6 +20,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.chartboost.sdk.Chartboost
 import com.chartboost.sdk.callbacks.StartCallback
 import com.chartboost.sdk.events.StartError
+import com.chartboost.sdk.privacy.model.CCPA
 import com.chartboost.sdk.privacy.model.COPPA
 import com.chartboost.sdk.privacy.model.GDPR
 import com.google.ads.mediation.adaptertestkit.AdErrorMatcher
@@ -311,6 +312,96 @@ class ChartboostInitializerTest {
       ChartboostInitializer.getInstance().initialize(context, chartboostParams, listener)
 
       mockChartboost.verify({ Chartboost.addDataUseConsent(any(), any<GDPR>()) }, never())
+    }
+  }
+
+  @Test
+  fun initialize_calledWhileAlreadyInitialized_appliesUsPrivacyConsentAgain() {
+    mockStatic(ChartboostAdapterUtils::class.java).use { mockAdapterUtils ->
+      mockAdapterUtils
+        .`when`<CCPA.CCPA_CONSENT> { ChartboostAdapterUtils.readUsPrivacyConsent(any()) }
+        .thenReturn(CCPA.CCPA_CONSENT.OPT_OUT_SALE, CCPA.CCPA_CONSENT.OPT_IN_SALE)
+
+      // First initialization succeeds, leaving the initializer in the isInitialized state.
+      val callbackCaptor = argumentCaptor<StartCallback>()
+      ChartboostInitializer.getInstance().initialize(context, chartboostParams, listener)
+      mockChartboost.verify {
+        Chartboost.startWithAppId(any(), any(), any(), callbackCaptor.capture())
+      }
+      callbackCaptor.firstValue.onStartCompleted(null)
+
+      // Second call hits the isInitialized early return, but consent must still be applied.
+      val ccpaCaptor = argumentCaptor<CCPA>()
+      ChartboostInitializer.getInstance().initialize(context, chartboostParams, listener2)
+
+      mockChartboost.verify(
+        { Chartboost.addDataUseConsent(eq(context), ccpaCaptor.capture()) },
+        times(2),
+      )
+      assertThat(ccpaCaptor.secondValue.consent).isEqualTo(CCPA.CCPA_CONSENT.OPT_IN_SALE.value)
+    }
+  }
+
+  @Test
+  fun initialize_calledWhileAlreadyInitializing_appliesUsPrivacyConsentAgain() {
+    mockStatic(ChartboostAdapterUtils::class.java).use { mockAdapterUtils ->
+      mockAdapterUtils
+        .`when`<CCPA.CCPA_CONSENT> { ChartboostAdapterUtils.readUsPrivacyConsent(any()) }
+        .thenReturn(CCPA.CCPA_CONSENT.OPT_OUT_SALE, CCPA.CCPA_CONSENT.OPT_IN_SALE)
+
+      // Start first initialization and leave it in progress (isInitializing stays true).
+      ChartboostInitializer.getInstance().initialize(context, chartboostParams, listener)
+
+      // Second call hits the isInitializing early return, but consent must still be applied.
+      val ccpaCaptor = argumentCaptor<CCPA>()
+      ChartboostInitializer.getInstance().initialize(context, chartboostParams, listener2)
+
+      mockChartboost.verify(
+        { Chartboost.addDataUseConsent(eq(context), ccpaCaptor.capture()) },
+        times(2),
+      )
+      assertThat(ccpaCaptor.secondValue.consent).isEqualTo(CCPA.CCPA_CONSENT.OPT_IN_SALE.value)
+    }
+  }
+
+  @Test
+  fun initialize_withUsPrivacyOptOutSale_addsOptOutSaleConsent() {
+    mockStatic(ChartboostAdapterUtils::class.java).use { mockAdapterUtils ->
+      mockAdapterUtils
+        .`when`<CCPA.CCPA_CONSENT> { ChartboostAdapterUtils.readUsPrivacyConsent(any()) }
+        .thenReturn(CCPA.CCPA_CONSENT.OPT_OUT_SALE)
+
+      val ccpaCaptor = argumentCaptor<CCPA>()
+      ChartboostInitializer.getInstance().initialize(context, chartboostParams, listener)
+
+      mockChartboost.verify { Chartboost.addDataUseConsent(eq(context), ccpaCaptor.capture()) }
+      assertThat(ccpaCaptor.firstValue.consent).isEqualTo(CCPA.CCPA_CONSENT.OPT_OUT_SALE.value)
+    }
+  }
+
+  @Test
+  fun initialize_withUsPrivacyOptInSale_addsOptInSaleConsent() {
+    mockStatic(ChartboostAdapterUtils::class.java).use { mockAdapterUtils ->
+      mockAdapterUtils
+        .`when`<CCPA.CCPA_CONSENT> { ChartboostAdapterUtils.readUsPrivacyConsent(any()) }
+        .thenReturn(CCPA.CCPA_CONSENT.OPT_IN_SALE)
+
+      val ccpaCaptor = argumentCaptor<CCPA>()
+      ChartboostInitializer.getInstance().initialize(context, chartboostParams, listener)
+
+      mockChartboost.verify { Chartboost.addDataUseConsent(eq(context), ccpaCaptor.capture()) }
+      assertThat(ccpaCaptor.firstValue.consent).isEqualTo(CCPA.CCPA_CONSENT.OPT_IN_SALE.value)
+    }
+  }
+
+  @Test
+  fun initialize_withNoUsPrivacyConsent_doesNotAddCcpaConsent() {
+    // readUsPrivacyConsent() is left unstubbed on the fully mocked ChartboostAdapterUtils, so it
+    // returns null, same as when the CMP has not written a US Privacy String.
+    mockStatic(ChartboostAdapterUtils::class.java).use {
+      ChartboostInitializer.getInstance().initialize(context, chartboostParams, listener)
+
+      mockChartboost.verify({ Chartboost.addDataUseConsent(any(), any<CCPA>()) }, never())
     }
   }
 

--- a/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostInterstitialAdTest.kt
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostInterstitialAdTest.kt
@@ -217,11 +217,7 @@ class ChartboostInterstitialAdTest {
   }
 
   @Test
-  fun showAd_adNotCachedOrNull_logsWarningAndDoesNotShow() {
-    // When ad is null
-    interstitialAd.showAd(context)
-
-    // When ad is not cached
+  fun showAd_adNotCached_stillCallsShow() {
     val serverParameters =
       bundleOf(
         KEY_APP_ID to TEST_APP_ID,
@@ -242,8 +238,13 @@ class ChartboostInterstitialAdTest {
         interstitialAd.showAd(context)
 
         val createdInterstitial = mockedInterstitialConstruction.constructed().first()
-        verify(createdInterstitial, never()).show()
+        verify(createdInterstitial).show()
       }
+  }
+
+  @Test
+  fun showAd_adIsNull_doesNotThrowException() {
+    interstitialAd.showAd(context)
   }
 
   @Test

--- a/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostInterstitialAdTest.kt
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostInterstitialAdTest.kt
@@ -283,6 +283,30 @@ class ChartboostInterstitialAdTest {
   }
 
   @Test
+  fun onAdDismiss_doesNotDestroyInterstitialAd() {
+    val serverParameters =
+      bundleOf(
+        KEY_APP_ID to TEST_APP_ID,
+        KEY_APP_SIGNATURE to TEST_APP_SIGNATURE,
+        KEY_AD_LOCATION to TEST_LOCATION,
+      )
+    val config =
+      createMediationInterstitialAdConfiguration(
+        context = context,
+        serverParameters = serverParameters,
+      )
+
+    mockConstruction(Interstitial::class.java).use { mockedInterstitialConstruction ->
+      interstitialAd.loadAd(config)
+      val createdInterstitial = mockedInterstitialConstruction.constructed().first()
+
+      interstitialAd.onAdDismiss(dismissEvent)
+
+      verify(createdInterstitial, never()).destroy()
+    }
+  }
+
+  @Test
   fun onImpressionRecorded_invokesReportAdImpression() {
     interstitialAd.onAdLoaded(cacheEvent, null)
 
@@ -305,6 +329,33 @@ class ChartboostInterstitialAdTest {
   }
 
   @Test
+  fun onAdShown_withShowError_destroysInterstitialAd() {
+    val serverParameters =
+      bundleOf(
+        KEY_APP_ID to TEST_APP_ID,
+        KEY_APP_SIGNATURE to TEST_APP_SIGNATURE,
+        KEY_AD_LOCATION to TEST_LOCATION,
+      )
+    val config =
+      createMediationInterstitialAdConfiguration(
+        context = context,
+        serverParameters = serverParameters,
+      )
+    whenever(showError.code) doReturn showErrorCode
+    whenever(showErrorCode.errorCode) doReturn ERROR_CODE
+    whenever(showError.toString()) doReturn ERROR_MESSAGE
+
+    mockConstruction(Interstitial::class.java).use { mockedInterstitialConstruction ->
+      interstitialAd.loadAd(config)
+      val createdInterstitial = mockedInterstitialConstruction.constructed().first()
+
+      interstitialAd.onAdShown(showEvent, showError)
+
+      verify(createdInterstitial).destroy()
+    }
+  }
+
+  @Test
   fun onAdShown_withoutShowError_invokesOnAdOpened() {
     interstitialAd.onAdLoaded(cacheEvent, null)
 
@@ -324,6 +375,81 @@ class ChartboostInterstitialAdTest {
 
     verify(mediationAdLoadCallback).onFailure(argThat(AdErrorMatcher(expectedAdError)))
     verify(mediationAdLoadCallback, never()).onSuccess(any())
+  }
+
+  @Test
+  fun onAdLoaded_withCacheError_destroysInterstitialAd() {
+    val serverParameters =
+      bundleOf(
+        KEY_APP_ID to TEST_APP_ID,
+        KEY_APP_SIGNATURE to TEST_APP_SIGNATURE,
+        KEY_AD_LOCATION to TEST_LOCATION,
+      )
+    val config =
+      createMediationInterstitialAdConfiguration(
+        context = context,
+        serverParameters = serverParameters,
+      )
+    whenever(cacheError.code) doReturn cacheErrorCode
+    whenever(cacheErrorCode.errorCode) doReturn ERROR_CODE
+    whenever(cacheError.toString()) doReturn ERROR_MESSAGE
+
+    mockConstruction(Interstitial::class.java).use { mockedInterstitialConstruction ->
+      interstitialAd.loadAd(config)
+      val createdInterstitial = mockedInterstitialConstruction.constructed().first()
+
+      interstitialAd.onAdLoaded(cacheEvent, cacheError)
+
+      verify(createdInterstitial).destroy()
+    }
+  }
+
+  @Test
+  fun onAdLoaded_withoutCacheError_doesNotDestroyInterstitialAd() {
+    val serverParameters =
+      bundleOf(
+        KEY_APP_ID to TEST_APP_ID,
+        KEY_APP_SIGNATURE to TEST_APP_SIGNATURE,
+        KEY_AD_LOCATION to TEST_LOCATION,
+      )
+    val config =
+      createMediationInterstitialAdConfiguration(
+        context = context,
+        serverParameters = serverParameters,
+      )
+
+    mockConstruction(Interstitial::class.java).use { mockedConstruction ->
+      interstitialAd.loadAd(config)
+      val createdInterstitial = mockedConstruction.constructed().first()
+
+      interstitialAd.onAdLoaded(cacheEvent, null)
+
+      verify(createdInterstitial, never()).destroy()
+    }
+  }
+
+  @Test
+  fun onAdShown_withoutShowError_doesNotDestroyInterstitialAd() {
+    val serverParameters =
+      bundleOf(
+        KEY_APP_ID to TEST_APP_ID,
+        KEY_APP_SIGNATURE to TEST_APP_SIGNATURE,
+        KEY_AD_LOCATION to TEST_LOCATION,
+      )
+    val config =
+      createMediationInterstitialAdConfiguration(
+        context = context,
+        serverParameters = serverParameters,
+      )
+
+    mockConstruction(Interstitial::class.java).use { mockedConstruction ->
+      interstitialAd.loadAd(config)
+      val createdInterstitial = mockedConstruction.constructed().first()
+
+      interstitialAd.onAdShown(showEvent, null)
+
+      verify(createdInterstitial, never()).destroy()
+    }
   }
 
   @Test

--- a/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostInterstitialAdTest.kt
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostInterstitialAdTest.kt
@@ -31,6 +31,7 @@ import com.chartboost.sdk.events.ImpressionEvent
 import com.chartboost.sdk.events.ShowError
 import com.chartboost.sdk.events.ShowEvent
 import com.chartboost.sdk.events.StartError
+import com.chartboost.sdk.internal.caching.ExpirationReason
 import com.google.ads.mediation.adaptertestkit.AdErrorMatcher
 import com.google.ads.mediation.adaptertestkit.createMediationInterstitialAdConfiguration
 import com.google.ads.mediation.chartboost.ChartboostAdapterUtils.KEY_AD_LOCATION
@@ -487,6 +488,8 @@ class ChartboostInterstitialAdTest {
 
   @Test
   fun onAdExpired_doesNotThrowException() {
+    whenever(expirationEvent.reason) doReturn ExpirationReason.TTL_EXPIRED
+
     interstitialAd.onAdExpired(expirationEvent)
   }
 

--- a/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostRewardedAdTest.kt
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostRewardedAdTest.kt
@@ -244,6 +244,27 @@ class ChartboostRewardedAdTest {
   }
 
   @Test
+  fun onAdDismiss_doesNotDestroyRewardedAd() {
+    val serverParameters =
+      bundleOf(
+        KEY_APP_ID to TEST_APP_ID,
+        KEY_APP_SIGNATURE to TEST_APP_SIGNATURE,
+        KEY_AD_LOCATION to TEST_LOCATION,
+      )
+    val config =
+      createMediationRewardedAdConfiguration(context = context, serverParameters = serverParameters)
+
+    mockConstruction(Rewarded::class.java).use { mockedRewardedConstruction ->
+      rewardedAd.loadAd(config)
+      val createdRewarded = mockedRewardedConstruction.constructed().first()
+
+      rewardedAd.onAdDismiss(dismissEvent)
+
+      verify(createdRewarded, never()).destroy()
+    }
+  }
+
+  @Test
   fun onImpressionRecorded_invokesReportAdImpression() {
     rewardedAd.onAdLoaded(cacheEvent, null)
 
@@ -263,6 +284,30 @@ class ChartboostRewardedAdTest {
     rewardedAd.onAdShown(showEvent, showError)
 
     verify(rewardedAdCallback).onAdFailedToShow(argThat(AdErrorMatcher(expectedAdError)))
+  }
+
+  @Test
+  fun onAdShown_withShowError_destroysRewardedAd() {
+    val serverParameters =
+      bundleOf(
+        KEY_APP_ID to TEST_APP_ID,
+        KEY_APP_SIGNATURE to TEST_APP_SIGNATURE,
+        KEY_AD_LOCATION to TEST_LOCATION,
+      )
+    val config =
+      createMediationRewardedAdConfiguration(context = context, serverParameters = serverParameters)
+    whenever(showError.code) doReturn showErrorCode
+    whenever(showErrorCode.errorCode) doReturn ERROR_CODE
+    whenever(showError.toString()) doReturn ERROR_MESSAGE
+
+    mockConstruction(Rewarded::class.java).use { mockedRewardedConstruction ->
+      rewardedAd.loadAd(config)
+      val createdRewarded = mockedRewardedConstruction.constructed().first()
+
+      rewardedAd.onAdShown(showEvent, showError)
+
+      verify(createdRewarded).destroy()
+    }
   }
 
   @Test
@@ -286,6 +331,78 @@ class ChartboostRewardedAdTest {
 
     verify(mediationAdLoadCallback).onFailure(argThat(AdErrorMatcher(expectedAdError)))
     verify(mediationAdLoadCallback, never()).onSuccess(any())
+  }
+
+  @Test
+  fun onAdLoaded_withCacheError_destroysRewardedAd() {
+    val serverParameters =
+      bundleOf(
+        KEY_APP_ID to TEST_APP_ID,
+        KEY_APP_SIGNATURE to TEST_APP_SIGNATURE,
+        KEY_AD_LOCATION to TEST_LOCATION,
+      )
+    val config =
+      createMediationRewardedAdConfiguration(context = context, serverParameters = serverParameters)
+    whenever(cacheError.code) doReturn cacheErrorCode
+    whenever(cacheErrorCode.errorCode) doReturn ERROR_CODE
+    whenever(cacheError.toString()) doReturn ERROR_MESSAGE
+
+    mockConstruction(Rewarded::class.java).use { mockedRewardedConstruction ->
+      rewardedAd.loadAd(config)
+      val createdRewarded = mockedRewardedConstruction.constructed().first()
+
+      rewardedAd.onAdLoaded(cacheEvent, cacheError)
+
+      verify(createdRewarded).destroy()
+    }
+  }
+
+  @Test
+  fun onAdLoaded_withoutCacheError_doesNotDestroyRewardedAd() {
+    val serverParameters =
+      bundleOf(
+        KEY_APP_ID to TEST_APP_ID,
+        KEY_APP_SIGNATURE to TEST_APP_SIGNATURE,
+        KEY_AD_LOCATION to TEST_LOCATION,
+      )
+    val config =
+      createMediationRewardedAdConfiguration(
+        context = context,
+        serverParameters = serverParameters,
+      )
+
+    mockConstruction(Rewarded::class.java).use { mockedConstruction ->
+      rewardedAd.loadAd(config)
+      val createdRewarded = mockedConstruction.constructed().first()
+
+      rewardedAd.onAdLoaded(cacheEvent, null)
+
+      verify(createdRewarded, never()).destroy()
+    }
+  }
+
+  @Test
+  fun onAdShown_withoutShowError_doesNotDestroyRewardedAd() {
+    val serverParameters =
+      bundleOf(
+        KEY_APP_ID to TEST_APP_ID,
+        KEY_APP_SIGNATURE to TEST_APP_SIGNATURE,
+        KEY_AD_LOCATION to TEST_LOCATION,
+      )
+    val config =
+      createMediationRewardedAdConfiguration(
+        context = context,
+        serverParameters = serverParameters,
+      )
+
+    mockConstruction(Rewarded::class.java).use { mockedConstruction ->
+      rewardedAd.loadAd(config)
+      val createdRewarded = mockedConstruction.constructed().first()
+
+      rewardedAd.onAdShown(showEvent, null)
+
+      verify(createdRewarded, never()).destroy()
+    }
   }
 
   @Test

--- a/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostRewardedAdTest.kt
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostRewardedAdTest.kt
@@ -131,6 +131,62 @@ class ChartboostRewardedAdTest {
   }
 
   @Test
+  fun loadAd_emptyLocation_invokesOnFailureWithInvalidServerParametersError() {
+    val serverParameters =
+      bundleOf(KEY_APP_ID to TEST_APP_ID, KEY_APP_SIGNATURE to TEST_APP_SIGNATURE)
+    val config =
+      createMediationRewardedAdConfiguration(context = context, serverParameters = serverParameters)
+    val expectedAdError =
+      AdError(ERROR_INVALID_SERVER_PARAMETERS, "Missing or invalid location.", ERROR_DOMAIN)
+
+    mockStatic(ChartboostAdapterUtils::class.java).use { mockAdapterUtils ->
+      val params =
+        ChartboostParams().apply {
+          appId = TEST_APP_ID
+          appSignature = TEST_APP_SIGNATURE
+          location = ""
+        }
+      mockAdapterUtils
+        .`when`<ChartboostParams> { ChartboostAdapterUtils.createChartboostParams(any()) }
+        .thenReturn(params)
+      mockAdapterUtils
+        .`when`<Boolean> { ChartboostAdapterUtils.isValidChartboostParams(params) }
+        .thenReturn(true)
+
+      mockConstruction(Rewarded::class.java).use { mockedRewardedConstruction ->
+        rewardedAd.loadAd(config)
+
+        verify(mediationAdLoadCallback).onFailure(argThat(AdErrorMatcher(expectedAdError)))
+        assertThat(mockedRewardedConstruction.constructed()).isEmpty()
+      }
+    }
+  }
+
+  @Test
+  fun loadAd_whitespaceOnlyLocation_invokesOnFailureWithInvalidServerParametersError() {
+    // A whitespace-only Ad Location is not empty, so createChartboostParams does not replace it
+    // with the default location. It trims down to an empty string instead. This drives that real
+    // parsing path rather than mocking it.
+    val serverParameters =
+      bundleOf(
+        KEY_APP_ID to TEST_APP_ID,
+        KEY_APP_SIGNATURE to TEST_APP_SIGNATURE,
+        KEY_AD_LOCATION to "   ",
+      )
+    val config =
+      createMediationRewardedAdConfiguration(context = context, serverParameters = serverParameters)
+    val expectedAdError =
+      AdError(ERROR_INVALID_SERVER_PARAMETERS, "Missing or invalid location.", ERROR_DOMAIN)
+
+    mockConstruction(Rewarded::class.java).use { mockedRewardedConstruction ->
+      rewardedAd.loadAd(config)
+
+      verify(mediationAdLoadCallback).onFailure(argThat(AdErrorMatcher(expectedAdError)))
+      assertThat(mockedRewardedConstruction.constructed()).isEmpty()
+    }
+  }
+
+  @Test
   fun loadAd_sdkInitializationFails_invokesOnFailureWithSdkError() {
     mockChartboost
       .`when`<Unit> { Chartboost.startWithAppId(any(), any(), any(), any()) }

--- a/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostRewardedAdTest.kt
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostRewardedAdTest.kt
@@ -178,11 +178,7 @@ class ChartboostRewardedAdTest {
   }
 
   @Test
-  fun showAd_adNotCachedOrNull_logsWarningAndDoesNotShow() {
-    // When ad is null
-    rewardedAd.showAd(context)
-
-    // When ad is not cached
+  fun showAd_adNotCached_stillCallsShow() {
     val serverParameters =
       bundleOf(
         KEY_APP_ID to TEST_APP_ID,
@@ -198,8 +194,13 @@ class ChartboostRewardedAdTest {
         rewardedAd.showAd(context)
 
         val createdRewarded = mockedRewardedConstruction.constructed().first()
-        verify(createdRewarded, never()).show()
+        verify(createdRewarded).show()
       }
+  }
+
+  @Test
+  fun showAd_adIsNull_doesNotThrowException() {
+    rewardedAd.showAd(context)
   }
 
   @Test

--- a/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostRewardedAdTest.kt
+++ b/ThirdPartyAdapters/chartboost/chartboost/src/test/kotlin/com/google/ads/mediation/chartboost/ChartboostRewardedAdTest.kt
@@ -32,6 +32,7 @@ import com.chartboost.sdk.events.RewardEvent
 import com.chartboost.sdk.events.ShowError
 import com.chartboost.sdk.events.ShowEvent
 import com.chartboost.sdk.events.StartError
+import com.chartboost.sdk.internal.caching.ExpirationReason
 import com.google.ads.mediation.adaptertestkit.AdErrorMatcher
 import com.google.ads.mediation.adaptertestkit.createMediationRewardedAdConfiguration
 import com.google.ads.mediation.chartboost.ChartboostAdapterUtils.KEY_AD_LOCATION
@@ -496,6 +497,8 @@ class ChartboostRewardedAdTest {
 
   @Test
   fun onAdExpired_doesNotThrowException() {
+    whenever(expirationEvent.reason) doReturn ExpirationReason.TTL_EXPIRED
+
     rewardedAd.onAdExpired(expirationEvent)
   }
 


### PR DESCRIPTION
## What was broken

- `showAd()` on an interstitial or rewarded ad that was no longer cached returned without calling `onAdFailedToShow()`, so the publisher callback never fired. The guard used `isCached()`, which the Chartboost SDK deprecated because `show()` performs the same check and reports `NO_CACHED_AD`.
- Interstitial and rewarded ads were never released after a failed load or show.
- Banners were never detached after a load or show failure.
- A GDPR consent change made after initialization was dropped, since consent was applied only on first init.
- A whitespace-only rewarded ad location produced a "session not started" error instead of an invalid location error.
- The rewarded expiration log referred to a banner, and no format logged the expiration reason.
- The default ad location was `default`, but Chartboost aggregates unnamed locations under `Default`, silently splitting publisher reporting.
- Chartboost's 300x600 half page banner size was never mapped.
- CCPA was never forwarded, though the adapter already forwards GDPR from the same source.

## What changed

Eleven commits, one per fix. One is a refactor scoping the per-format ad objects to their load methods, which is what makes the banner detach fix possible.

CCPA forwarding mirrors the existing GDPR path: it reads `IABUSPrivacy_String` from the app's default `SharedPreferences`, maps the opt-out-of-sale character, and forwards on every initialize call. A CMP value takes precedence over a CCPA consent the app set directly, matching GDPR.

`build.gradle` is untouched, since your release tooling owns the version and dependencies. Changelog entries are under `#### Next version`.

## Verification

- `:chartboost:testDebugUnitTest` — 157 tests, 0 failures, 14 new.
- `:chartboost:assembleRelease` — green.
- CCPA opt-out polarity checked against the IAB US Privacy String spec and the Chartboost SDK's own enum values.
- HALFPAGE checked against the published 9.14.0 AAR rather than a release tag.

Happy to split this up if you would rather review the fixes separately.
