### PR TITLE
DTExchange removed onAdOpened() callback from Native ad onAdImpression

### DIFF
--- a/ThirdPartyAdapters/dtexchange/dtexchange/src/main/java/com/google/ads/mediation/fyber/DTExchangeNativeAdMapper.kt
+++ b/ThirdPartyAdapters/dtexchange/dtexchange/src/main/java/com/google/ads/mediation/fyber/DTExchangeNativeAdMapper.kt
@@ -71,7 +71,6 @@ class DTExchangeNativeAdMapper(
         controller.eventsListener =
           object : NativeAdEventsListener() {
             override fun onAdImpression(adSpot: InneractiveAdSpot) {
-              mediationNativeAdCallback?.onAdOpened()
               mediationNativeAdCallback?.reportAdImpression()
             }
 

--- a/ThirdPartyAdapters/dtexchange/dtexchange/src/test/kotlin/com/google/ads/mediation/fyber/DTExchangeNativeAdMapperTest.kt
+++ b/ThirdPartyAdapters/dtexchange/dtexchange/src/test/kotlin/com/google/ads/mediation/fyber/DTExchangeNativeAdMapperTest.kt
@@ -188,7 +188,6 @@ class DTExchangeNativeAdMapperTest {
 
       eventListenerCaptor.firstValue.onAdImpression(mock())
 
-      assertThat(nativeAdCallback.isOpened).isTrue()
       assertThat(nativeAdCallback.isImpressionReported).isTrue()
     }
   }


### PR DESCRIPTION
The DTExchange native ad mapper was incorrectly calling onAdOpened() from onAdImpression(), firing it on every impression regardless of user interaction. This PR removes that erroneous call so onAdOpened only triggers from the actual click path, matching the documented behavior. Updated the related unit test to drop the now-invalid isOpened assertion on impression.