### PR TITLE
[inmobi] UnifiedNativeAdMapper.destroy() wired to InMobiNative.destroy()

### DIFF
--- a/ThirdPartyAdapters/inmobi/CHANGELOG.md
+++ b/ThirdPartyAdapters/inmobi/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## InMobi Android Mediation Adapter Changelog
 
-#### Version 11.4.1.2 (In progress)
+#### Version 11.4.1.2
 - Override `UnifiedNativeAdMapper.destroy()` to call `InMobiNative.destroy()` when GMA invokes full native ad teardown. `untrackView()` still only calls `unTrackViews()` so feed refresh/swap can re-track.
 
 #### Version 11.4.1.1

--- a/ThirdPartyAdapters/inmobi/CHANGELOG.md
+++ b/ThirdPartyAdapters/inmobi/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## InMobi Android Mediation Adapter Changelog
 
+#### Version 11.4.1.2 (In progress)
+- Override `UnifiedNativeAdMapper.destroy()` to call `InMobiNative.destroy()` when GMA invokes full native ad teardown. `untrackView()` still only calls `unTrackViews()` so feed refresh/swap can re-track.
+
 #### Version 11.4.1.1
 - Use `BitmapFactory.Options` with downsampling to prevent potential OOM errors when downloading images.
 

--- a/ThirdPartyAdapters/inmobi/CHANGELOG.md
+++ b/ThirdPartyAdapters/inmobi/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## InMobi Android Mediation Adapter Changelog
 
 #### Version 11.4.1.2
-- Override `UnifiedNativeAdMapper.destroy()` to call `InMobiNative.destroy()` when GMA invokes full native ad teardown. `untrackView()` still only calls `unTrackViews()` so feed refresh/swap can re-track.
+- Override `UnifiedNativeAdMapper.destroy()` to call `InMobiNative.destroy()`.
+
+Built and tested with:
+- Google Mobile Ads SDK version 25.4.0.
+- Google Mobile Ads Next-Gen SDK version 1.4.0.
+- InMobi Kotlin SDK version 11.4.1.
 
 #### Version 11.4.1.1
 - Use `BitmapFactory.Options` with downsampling to prevent potential OOM errors when downloading images.

--- a/ThirdPartyAdapters/inmobi/inmobi/src/main/java/com/google/ads/mediation/inmobi/InMobiUnifiedNativeAdMapper.java
+++ b/ThirdPartyAdapters/inmobi/inmobi/src/main/java/com/google/ads/mediation/inmobi/InMobiUnifiedNativeAdMapper.java
@@ -187,6 +187,12 @@ public class InMobiUnifiedNativeAdMapper extends UnifiedNativeAdMapper {
   }
 
   @Override
+  public void destroy() {
+    super.destroy();
+    inMobiNativeWrapper.destroy();
+  }
+
+  @Override
   public void trackViews(View containerView, Map<String, View> clickableAssetViews,
       Map<String, View> nonclickableAssetViews) {
     setOverrideClickHandling(true);

--- a/ThirdPartyAdapters/inmobi/inmobi/src/test/kotlin/com/google/ads/mediation/inmobi/rtb/InMobiRtbNativeAdTest.kt
+++ b/ThirdPartyAdapters/inmobi/inmobi/src/test/kotlin/com/google/ads/mediation/inmobi/rtb/InMobiRtbNativeAdTest.kt
@@ -180,6 +180,15 @@ class InMobiRtbNativeAdTest {
   }
 
   @Test
+  fun destroy_invokesDestroy() {
+    rtbNativeAd.onAdLoadSucceeded(inMobiNativeWrapper.inMobiNative, adMetaInfo)
+
+    rtbNativeAd.inMobiUnifiedNativeAdMapper.destroy()
+
+    verify(wrappedNativeAd).destroy()
+  }
+
+  @Test
   fun onAdLoadSucceeded_whenShouldReturnUrlsForImageAssetsFalse_downloadsDrawables_invokesOnSuccessCallback() {
     ShadowBitmapFactory.setAllowInvalidImageData(true)
     val bitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888)

--- a/ThirdPartyAdapters/inmobi/inmobi/src/test/kotlin/com/google/ads/mediation/inmobi/waterfall/InMobiWaterfallNativeAdTest.kt
+++ b/ThirdPartyAdapters/inmobi/inmobi/src/test/kotlin/com/google/ads/mediation/inmobi/waterfall/InMobiWaterfallNativeAdTest.kt
@@ -185,6 +185,15 @@ class InMobiWaterfallNativeAdTest {
   }
 
   @Test
+  fun destroy_invokesDestroy() {
+    waterfallNativeAd.onAdLoadSucceeded(inMobiNativeWrapper.inMobiNative, adMetaInfo)
+
+    waterfallNativeAd.inMobiUnifiedNativeAdMapper.destroy()
+
+    verify(wrappedNativeAd).destroy()
+  }
+
+  @Test
   fun onAdLoadSucceeded_whenShouldReturnUrlsForImageAssetsFalse_downloadsDrawables_invokesOnSuccessCallback() {
     ShadowBitmapFactory.setAllowInvalidImageData(true)
     val bitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888)


### PR DESCRIPTION
## Summary
- Override `InMobiUnifiedNativeAdMapper.destroy()` to call `InMobiNative.destroy()` when GMA invokes full native ad teardown.
- Keep `untrackView()` mapped to `unTrackViews()` only, so feed refresh/swap can re-track the same mapper instance.

This PR is `InMobi/main` (includes https://github.com/InMobi/googleads-mobile-android-mediation/pull/65) into `googleads/main`.

## Context
GMA calls `untrackView()` on native refresh/swap and `destroy()` on full native teardown. The base `UnifiedNativeAdMapper.destroy()` is a no-op. `InMobiNativeWrapper.destroy()` already forwarded to `InMobiNative.destroy()`, but the mapper did not override `destroy()`, so GMA teardown never reached the InMobi SDK.

`untrackView()` must not destroy the native object. Destroying on untrack would break re-tracking after a feed recycle.

## Test plan
- [x] `./gradlew :inmobi:compileDebugJavaWithJavac :inmobi:compileDebugUnitTestKotlin`
- [x] `destroy_invokesDestroy` in `InMobiWaterfallNativeAdTest` and `InMobiRtbNativeAdTest`